### PR TITLE
Set up release-plz with git-cliff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ on:
     paths-ignore:
       - "**.md"
       - "LICENSE-*"
+      - "cliff.toml"
+      - "release-plz.toml"
   pull_request:
     branches: [main]
     paths-ignore:
       - "**.md"
       - "LICENSE-*"
+      - "cliff.toml"
+      - "release-plz.toml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,23 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,51 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/joshrotenberg/resp-rs
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}{{ commit.message | upper_first }}\
+            {% if commit.breaking %} [**breaking**]{% endif %}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"
+
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Performance" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^style", skip = true },
+    { message = "^ci", skip = true },
+]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,4 @@
+[workspace]
+changelog_config = "cliff.toml"
+git_release_enable = true
+git_tag_enable = true


### PR DESCRIPTION
## Summary

- Add release-plz GitHub Actions workflow for automated release PRs and crates.io publishing
- Add git-cliff configuration for conventional commit changelog generation
- Add `cliff.toml` and `release-plz.toml` to CI paths-ignore

## Setup required

Set the `CARGO_REGISTRY_TOKEN` secret in the repository settings for crates.io publishing.

## How it works

On every push to `main`, release-plz will:
1. Check if there are releasable changes (based on conventional commits)
2. Open/update a release PR with a changelog generated by git-cliff
3. When the release PR is merged, publish to crates.io and create a GitHub release with a git tag

## Test plan

- [x] Config files are valid TOML
- [x] Workflow uses pinned action versions
- [ ] Verify workflow runs after merge (will show in Actions tab)