### PR TITLE
Add proptest property tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
@@ -201,6 +228,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,10 +298,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is-terminal"
@@ -254,10 +379,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -337,6 +474,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,12 +502,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -423,8 +654,22 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "criterion",
+ "proptest",
  "redis-protocol",
  "thiserror",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -434,6 +679,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +698,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -497,6 +760,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,10 +803,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -540,6 +837,24 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -588,6 +903,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +968,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+proptest = "1"
 redis-protocol = { version = "6", features = ["resp2", "resp3", "bytes"] }
 
 [[bench]]

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -1,0 +1,222 @@
+use bytes::Bytes;
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Arbitrary frame generators
+// ---------------------------------------------------------------------------
+
+/// Generate a byte string that is safe for RESP simple strings / errors
+/// (no \r or \n characters).
+fn safe_line_bytes() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(
+        prop::num::u8::ANY.prop_filter("no CR/LF", |b| *b != b'\r' && *b != b'\n'),
+        0..128,
+    )
+}
+
+/// Generate an arbitrary RESP2 frame (recursive for arrays).
+fn arb_resp2_frame() -> impl Strategy<Value = resp_rs::resp2::Frame> {
+    use resp_rs::resp2::Frame;
+
+    let leaf = prop_oneof![
+        safe_line_bytes().prop_map(|b| Frame::SimpleString(Bytes::from(b))),
+        safe_line_bytes().prop_map(|b| Frame::Error(Bytes::from(b))),
+        any::<i64>().prop_map(Frame::Integer),
+        prop::option::of(prop::collection::vec(any::<u8>(), 0..256))
+            .prop_map(|opt| Frame::BulkString(opt.map(Bytes::from))),
+    ];
+
+    leaf.prop_recursive(
+        3,  // max depth
+        64, // max nodes
+        8,  // items per collection
+        |inner| prop::option::of(prop::collection::vec(inner, 0..8)).prop_map(Frame::Array),
+    )
+}
+
+/// Generate an arbitrary RESP3 frame (recursive for arrays/maps/sets/etc).
+fn arb_resp3_frame() -> impl Strategy<Value = resp_rs::resp3::Frame> {
+    use resp_rs::resp3::Frame;
+
+    let leaf = prop_oneof![
+        safe_line_bytes().prop_map(|b| Frame::SimpleString(Bytes::from(b))),
+        safe_line_bytes().prop_map(|b| Frame::Error(Bytes::from(b))),
+        any::<i64>().prop_map(Frame::Integer),
+        prop::option::of(prop::collection::vec(any::<u8>(), 0..256))
+            .prop_map(|opt| Frame::BulkString(opt.map(Bytes::from))),
+        Just(Frame::Null),
+        any::<bool>().prop_map(Frame::Boolean),
+        // Use finite f64 only (NaN breaks PartialEq, special floats have separate repr)
+        any::<f64>()
+            .prop_filter("finite", |f| f.is_finite())
+            .prop_map(Frame::Double),
+        safe_line_bytes().prop_map(|b| Frame::BigNumber(Bytes::from(b))),
+        prop::collection::vec(any::<u8>(), 0..256).prop_map(|b| Frame::BlobError(Bytes::from(b))),
+        // VerbatimString: 3-byte format tag + arbitrary content
+        (
+            prop::collection::vec(
+                prop::num::u8::ANY.prop_filter("no colon/cr/lf", |b| {
+                    *b != b':' && *b != b'\r' && *b != b'\n'
+                }),
+                3..=3,
+            ),
+            prop::collection::vec(any::<u8>(), 0..128),
+        )
+            .prop_map(|(fmt, content)| {
+                Frame::VerbatimString(Bytes::from(fmt), Bytes::from(content))
+            }),
+    ];
+
+    leaf.prop_recursive(
+        3,  // max depth
+        64, // max nodes
+        6,  // items per collection
+        |inner| {
+            prop_oneof![
+                // Array
+                prop::option::of(prop::collection::vec(inner.clone(), 0..6)).prop_map(Frame::Array),
+                // Set
+                prop::collection::vec(inner.clone(), 0..6).prop_map(Frame::Set),
+                // Map
+                prop::collection::vec((inner.clone(), inner.clone()), 0..4).prop_map(Frame::Map),
+                // Attribute
+                prop::collection::vec((inner.clone(), inner.clone()), 0..4)
+                    .prop_map(Frame::Attribute),
+                // Push
+                prop::collection::vec(inner, 0..6).prop_map(Frame::Push),
+            ]
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// RESP2 property tests
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// Roundtrip: for any valid RESP2 frame, serialize then parse should yield
+    /// the identical frame with no remaining bytes.
+    #[test]
+    fn resp2_roundtrip(frame in arb_resp2_frame()) {
+        let wire = resp_rs::resp2::frame_to_bytes(&frame);
+        let (parsed, rest) = resp_rs::resp2::parse_frame(wire).unwrap();
+        prop_assert_eq!(&parsed, &frame);
+        prop_assert!(rest.is_empty(), "leftover bytes: {:?}", rest);
+    }
+
+    /// Arbitrary bytes should never cause a panic -- only Ok or Err.
+    #[test]
+    fn resp2_no_panic(data in prop::collection::vec(any::<u8>(), 0..512)) {
+        let _ = resp_rs::resp2::parse_frame(Bytes::from(data));
+    }
+
+    /// If parse succeeds consuming some prefix, re-parsing that exact prefix
+    /// should produce the same result.
+    #[test]
+    fn resp2_deterministic(data in prop::collection::vec(any::<u8>(), 1..512)) {
+        let input = Bytes::from(data);
+        if let Ok((frame1, rest1)) = resp_rs::resp2::parse_frame(input.clone()) {
+            let consumed = input.len() - rest1.len();
+            let prefix = input.slice(..consumed);
+            let (frame2, rest2) = resp_rs::resp2::parse_frame(prefix).unwrap();
+            prop_assert_eq!(frame1, frame2);
+            prop_assert!(rest2.is_empty());
+        }
+    }
+
+    /// Concatenating serialized frames produces parseable pipelined data.
+    #[test]
+    fn resp2_pipeline(
+        frames in prop::collection::vec(arb_resp2_frame(), 1..8)
+    ) {
+        let mut wire = Vec::new();
+        for f in &frames {
+            wire.extend_from_slice(&resp_rs::resp2::frame_to_bytes(f));
+        }
+        let mut input = Bytes::from(wire);
+        for expected in &frames {
+            let (parsed, rest) = resp_rs::resp2::parse_frame(input).unwrap();
+            prop_assert_eq!(&parsed, expected);
+            input = rest;
+        }
+        prop_assert!(input.is_empty());
+    }
+
+    /// The streaming parser should produce the same frames as direct parsing.
+    #[test]
+    fn resp2_streaming_matches_direct(frame in arb_resp2_frame()) {
+        let wire = resp_rs::resp2::frame_to_bytes(&frame);
+
+        let mut parser = resp_rs::resp2::Parser::new();
+        parser.feed(wire);
+        let parsed = parser.next_frame().unwrap().unwrap();
+        prop_assert_eq!(&parsed, &frame);
+        prop_assert!(parser.next_frame().unwrap().is_none());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RESP3 property tests
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// Roundtrip: for any valid RESP3 frame, serialize then parse should yield
+    /// the identical frame with no remaining bytes.
+    #[test]
+    fn resp3_roundtrip(frame in arb_resp3_frame()) {
+        let wire = resp_rs::resp3::frame_to_bytes(&frame);
+        let (parsed, rest) = resp_rs::resp3::parse_frame(wire).unwrap();
+        prop_assert_eq!(&parsed, &frame);
+        prop_assert!(rest.is_empty(), "leftover bytes: {:?}", rest);
+    }
+
+    /// Arbitrary bytes should never cause a panic -- only Ok or Err.
+    #[test]
+    fn resp3_no_panic(data in prop::collection::vec(any::<u8>(), 0..512)) {
+        let _ = resp_rs::resp3::parse_frame(Bytes::from(data));
+    }
+
+    /// If parse succeeds consuming some prefix, re-parsing that exact prefix
+    /// should produce the same result.
+    #[test]
+    fn resp3_deterministic(data in prop::collection::vec(any::<u8>(), 1..512)) {
+        let input = Bytes::from(data);
+        if let Ok((frame1, rest1)) = resp_rs::resp3::parse_frame(input.clone()) {
+            let consumed = input.len() - rest1.len();
+            let prefix = input.slice(..consumed);
+            let (frame2, rest2) = resp_rs::resp3::parse_frame(prefix).unwrap();
+            prop_assert_eq!(frame1, frame2);
+            prop_assert!(rest2.is_empty());
+        }
+    }
+
+    /// Concatenating serialized frames produces parseable pipelined data.
+    #[test]
+    fn resp3_pipeline(
+        frames in prop::collection::vec(arb_resp3_frame(), 1..8)
+    ) {
+        let mut wire = Vec::new();
+        for f in &frames {
+            wire.extend_from_slice(&resp_rs::resp3::frame_to_bytes(f));
+        }
+        let mut input = Bytes::from(wire);
+        for expected in &frames {
+            let (parsed, rest) = resp_rs::resp3::parse_frame(input).unwrap();
+            prop_assert_eq!(&parsed, expected);
+            input = rest;
+        }
+        prop_assert!(input.is_empty());
+    }
+
+    /// The streaming parser should produce the same frames as direct parsing.
+    #[test]
+    fn resp3_streaming_matches_direct(frame in arb_resp3_frame()) {
+        let wire = resp_rs::resp3::frame_to_bytes(&frame);
+
+        let mut parser = resp_rs::resp3::Parser::new();
+        parser.feed(wire);
+        let parsed = parser.next_frame().unwrap().unwrap();
+        prop_assert_eq!(&parsed, &frame);
+        prop_assert!(parser.next_frame().unwrap().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `proptest` as a dev-dependency
- Add 10 property tests covering both RESP2 and RESP3

## Properties tested

| Property | RESP2 | RESP3 | Description |
|----------|-------|-------|-------------|
| Roundtrip | x | x | `parse(serialize(frame)) == frame` for arbitrary generated frames |
| No panics | x | x | Arbitrary bytes never cause a panic |
| Deterministic | x | x | Re-parsing the consumed prefix gives the same result |
| Pipeline | x | x | Concatenated serialized frames parse correctly in sequence |
| Streaming parity | x | x | Streaming parser matches direct parsing |

Frame generators produce recursive structures (nested arrays, maps, sets, etc.) up to depth 3.

## Test plan

- [x] `cargo test --test property` passes (10/10)
- [x] clippy clean
- [x] fmt clean