### PR TITLE
Document intentional protocol permissiveness decisions

### DIFF
--- a/src/resp2.rs
+++ b/src/resp2.rs
@@ -6,6 +6,13 @@
 //! - Integer: `:42\r\n`
 //! - Bulk String: `$6\r\nfoobar\r\n` (or `$-1\r\n` for null)
 //! - Array: `*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n` (or `*-1\r\n` for null)
+//!
+//! # Protocol permissiveness
+//!
+//! Simple strings and errors are treated as raw bytes, not validated UTF-8.
+//! The parser accepts any byte sequence that does not contain `\r` or `\n`.
+//! This is intentional for zero-copy operation and compatibility with
+//! servers that may send non-UTF-8 data in these fields.
 
 use bytes::{BufMut, Bytes, BytesMut};
 

--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -2,6 +2,21 @@
 //!
 //! Parses RESP3 frames using `bytes::Bytes` for efficient, zero-copy operation.
 //! Supports all RESP3 data types, including fixed-length and streaming variants.
+//!
+//! # Protocol permissiveness
+//!
+//! - **Simple strings and errors** are treated as raw bytes, not validated UTF-8.
+//!   The parser accepts any byte sequence that does not contain `\r` or `\n`.
+//! - **Double parsing** accepts case-insensitive and non-canonical float spellings
+//!   (e.g., `INF`, `Infinity`, `NAN`) via Rust's `f64::parse`, then normalizes
+//!   them to canonical [`Frame::SpecialFloat`] values (`inf`, `-inf`, `nan`).
+//!   This means roundtrip is semantic (value-preserving) but not lexical
+//!   (byte-preserving) for non-canonical inputs.
+//! - **Streaming support** for blob errors and verbatim strings is limited:
+//!   `parse_streaming_sequence` passes through their streaming headers
+//!   (`!?\r\n`, `=?\r\n`) without accumulation, since RESP3 does not define
+//!   a chunk format for these types. Use low-level `parse_frame` to handle
+//!   these headers manually if needed.
 
 use bytes::{BufMut, Bytes, BytesMut};
 


### PR DESCRIPTION
## Summary

Add protocol permissiveness notes to module-level docs for both RESP2 and RESP3:

- Simple strings and errors are raw bytes, not UTF-8 validated
- RESP3 double parsing normalizes non-canonical float spellings to SpecialFloat
- Streaming support for blob errors and verbatim strings is limited (header passthrough only)

Closes #17

## Test plan

- [x] Doc tests pass
- [x] Docs build without warnings
- [x] clippy, fmt clean