### PR TITLE
Add opt-in unsafe parser behind `unsafe-internals` feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 CLAUDE.md
+tmp/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["redis", "resp", "protocol", "parser", "resp3"]
 categories = ["parser-implementations", "network-programming"]
 rust-version = "1.85"
 
+[features]
+unsafe-internals = []
+
 [dependencies]
 bytes = "1"
 thiserror = "2"
@@ -27,4 +30,8 @@ harness = false
 
 [[bench]]
 name = "comparison"
+harness = false
+
+[[bench]]
+name = "unsafe_experiment"
 harness = false

--- a/benches/unsafe_experiment.rs
+++ b/benches/unsafe_experiment.rs
@@ -1,0 +1,326 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+//! Experimental benchmark: how close to Redis C can we get with unsafe Rust?
+//!
+//! This is NOT production code. It strips all safety to find the theoretical
+//! floor for RESP parsing in Rust, answering: "is the gap inherent to Rust,
+//! or is it in our safety abstractions?"
+//!
+//! Three variants tested:
+//! 1. Current safe parser (baseline)
+//! 2. Unsafe offset-only parser (no Bytes, no bounds checks, no Frame construction)
+//! 3. Unsafe with Frame construction but unchecked buffer access
+
+use bytes::Bytes;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+// ---------------------------------------------------------------------------
+// Variant 2: Raw unsafe offset parser (no allocation, no Bytes, no Frame)
+// This is the Rust equivalent of Redis C's callback approach.
+// ---------------------------------------------------------------------------
+
+/// Bare minimum: find \r, return offset. No bounds checks.
+#[inline(always)]
+unsafe fn find_cr_unchecked(buf: *const u8, from: usize) -> usize {
+    let mut i = from;
+    while *buf.add(i) != b'\r' {
+        i += 1;
+    }
+    i
+}
+
+/// Parse a single RESP2 frame from raw pointer, returning bytes consumed.
+/// Only counts frames (like Redis C's noop callbacks).
+/// SAFETY: buf must point to valid, complete RESP2 data.
+#[inline(never)]
+unsafe fn parse_resp2_raw(buf: *const u8, pos: usize) -> usize {
+    let tag = *buf.add(pos);
+    match tag {
+        b'+' | b'-' => {
+            let cr = find_cr_unchecked(buf, pos + 1);
+            cr + 2 // skip \r\n
+        }
+        b':' => {
+            let cr = find_cr_unchecked(buf, pos + 1);
+            cr + 2
+        }
+        b'$' => {
+            let cr = find_cr_unchecked(buf, pos + 1);
+            // Parse length manually
+            let mut len: usize = 0;
+            let mut i = pos + 1;
+            let neg = *buf.add(i) == b'-';
+            if neg {
+                // $-1\r\n (null)
+                return cr + 2;
+            }
+            while i < cr {
+                len = len * 10 + (*buf.add(i) - b'0') as usize;
+                i += 1;
+            }
+            let data_start = cr + 2;
+            data_start + len + 2 // data + \r\n
+        }
+        b'*' => {
+            let cr = find_cr_unchecked(buf, pos + 1);
+            let mut i = pos + 1;
+            let neg = *buf.add(i) == b'-';
+            if neg {
+                return cr + 2;
+            }
+            let mut count: usize = 0;
+            while i < cr {
+                count = count * 10 + (*buf.add(i) - b'0') as usize;
+                i += 1;
+            }
+            let mut cursor = cr + 2;
+            for _ in 0..count {
+                cursor = parse_resp2_raw(buf, cursor);
+            }
+            cursor
+        }
+        _ => pos + 1, // shouldn't happen with valid data
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variant 3: Unsafe with Frame construction but unchecked buffer access
+// ---------------------------------------------------------------------------
+
+/// Parse RESP2 into Frame but skip all bounds checks.
+/// SAFETY: buf must be valid, complete RESP2 data.
+unsafe fn parse_resp2_unchecked_frame(input: &Bytes, pos: usize) -> (resp_rs::resp2::Frame, usize) {
+    use resp_rs::resp2::Frame;
+
+    let buf = input.as_ref();
+    let tag = *buf.get_unchecked(pos);
+    match tag {
+        b'+' => {
+            let cr = find_cr_unchecked(buf.as_ptr(), pos + 1);
+            (Frame::SimpleString(input.slice(pos + 1..cr)), cr + 2)
+        }
+        b'-' => {
+            let cr = find_cr_unchecked(buf.as_ptr(), pos + 1);
+            (Frame::Error(input.slice(pos + 1..cr)), cr + 2)
+        }
+        b':' => {
+            let cr = find_cr_unchecked(buf.as_ptr(), pos + 1);
+            // Simple atoi
+            let mut i = pos + 1;
+            let neg = *buf.get_unchecked(i) == b'-';
+            if neg {
+                i += 1;
+            }
+            let mut v: i64 = 0;
+            while i < cr {
+                v = v * 10 + (*buf.get_unchecked(i) - b'0') as i64;
+                i += 1;
+            }
+            if neg {
+                v = -v;
+            }
+            (Frame::Integer(v), cr + 2)
+        }
+        b'$' => {
+            let cr = find_cr_unchecked(buf.as_ptr(), pos + 1);
+            let mut i = pos + 1;
+            if *buf.get_unchecked(i) == b'-' {
+                return (Frame::BulkString(None), cr + 2);
+            }
+            let mut len: usize = 0;
+            while i < cr {
+                len = len * 10 + (*buf.get_unchecked(i) - b'0') as usize;
+                i += 1;
+            }
+            let data_start = cr + 2;
+            let data_end = data_start + len;
+            (
+                Frame::BulkString(Some(input.slice(data_start..data_end))),
+                data_end + 2,
+            )
+        }
+        b'*' => {
+            let cr = find_cr_unchecked(buf.as_ptr(), pos + 1);
+            let mut i = pos + 1;
+            if *buf.get_unchecked(i) == b'-' {
+                return (Frame::Array(None), cr + 2);
+            }
+            let mut count: usize = 0;
+            while i < cr {
+                count = count * 10 + (*buf.get_unchecked(i) - b'0') as usize;
+                i += 1;
+            }
+            let mut cursor = cr + 2;
+            let mut items = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (frame, next) = parse_resp2_unchecked_frame(input, cursor);
+                items.push(frame);
+                cursor = next;
+            }
+            (Frame::Array(Some(items)), cursor)
+        }
+        _ => unreachable!(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_simple_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unsafe_exp/simple_string");
+    let wire = "+OK\r\n";
+    let data = Bytes::from(wire);
+
+    group.bench_function("safe", |b| {
+        b.iter(|| resp_rs::resp2::parse_frame(data.clone()).unwrap());
+    });
+    group.bench_function("unsafe_raw", |b| {
+        let ptr = wire.as_ptr();
+        b.iter(|| unsafe { parse_resp2_raw(ptr, 0) });
+    });
+    group.bench_function("unsafe_frame", |b| {
+        b.iter(|| unsafe { parse_resp2_unchecked_frame(&data, 0) });
+    });
+    group.finish();
+}
+
+fn bench_bulk_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unsafe_exp/bulk_string");
+    let wire = "$11\r\nhello world\r\n";
+    let data = Bytes::from(wire);
+
+    group.bench_function("safe", |b| {
+        b.iter(|| resp_rs::resp2::parse_frame(data.clone()).unwrap());
+    });
+    group.bench_function("unsafe_raw", |b| {
+        let ptr = wire.as_ptr();
+        b.iter(|| unsafe { parse_resp2_raw(ptr, 0) });
+    });
+    group.bench_function("unsafe_frame", |b| {
+        b.iter(|| unsafe { parse_resp2_unchecked_frame(&data, 0) });
+    });
+    group.finish();
+}
+
+fn bench_integer(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unsafe_exp/integer");
+    let wire = ":9223372036854775807\r\n";
+    let data = Bytes::from(wire);
+
+    group.bench_function("safe", |b| {
+        b.iter(|| resp_rs::resp2::parse_frame(data.clone()).unwrap());
+    });
+    group.bench_function("unsafe_raw", |b| {
+        let ptr = wire.as_ptr();
+        b.iter(|| unsafe { parse_resp2_raw(ptr, 0) });
+    });
+    group.bench_function("unsafe_frame", |b| {
+        b.iter(|| unsafe { parse_resp2_unchecked_frame(&data, 0) });
+    });
+    group.finish();
+}
+
+fn bench_array_3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unsafe_exp/array_3");
+    let wire = "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n";
+    let data = Bytes::from(wire);
+
+    group.bench_function("safe", |b| {
+        b.iter(|| resp_rs::resp2::parse_frame(data.clone()).unwrap());
+    });
+    group.bench_function("unsafe_raw", |b| {
+        let ptr = wire.as_ptr();
+        b.iter(|| unsafe { parse_resp2_raw(ptr, 0) });
+    });
+    group.bench_function("unsafe_frame", |b| {
+        b.iter(|| unsafe { parse_resp2_unchecked_frame(&data, 0) });
+    });
+    group.finish();
+}
+
+fn bench_array_100(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unsafe_exp/array_100");
+
+    let mut wire = "*100\r\n".to_string();
+    for i in 0..100 {
+        let s = format!("value-{i:03}");
+        wire.push_str(&format!("${}\r\n{}\r\n", s.len(), s));
+    }
+    let data = Bytes::from(wire.clone());
+
+    group.bench_function("safe", |b| {
+        b.iter(|| resp_rs::resp2::parse_frame(data.clone()).unwrap());
+    });
+    group.bench_function("unsafe_raw", |b| {
+        let ptr = wire.as_ptr();
+        b.iter(|| unsafe { parse_resp2_raw(ptr, 0) });
+    });
+    group.bench_function("unsafe_frame", |b| {
+        b.iter(|| unsafe { parse_resp2_unchecked_frame(&data, 0) });
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Feature-gated parse_frame_unchecked benchmarks
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "unsafe-internals")]
+fn bench_feature_gated(c: &mut Criterion) {
+    let mut group = c.benchmark_group("feature_gated");
+
+    group.bench_function("resp2_simple_string", |b| {
+        let data = Bytes::from("+OK\r\n");
+        b.iter(|| unsafe { resp_rs::resp2::parse_frame_unchecked(data.clone()) });
+    });
+
+    group.bench_function("resp2_array_3", |b| {
+        let data = Bytes::from("*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n");
+        b.iter(|| unsafe { resp_rs::resp2::parse_frame_unchecked(data.clone()) });
+    });
+
+    group.bench_function("resp3_simple_string", |b| {
+        let data = Bytes::from("+OK\r\n");
+        b.iter(|| unsafe { resp_rs::resp3::parse_frame_unchecked(data.clone()) });
+    });
+
+    group.bench_function("resp3_array_3", |b| {
+        let data = Bytes::from("*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n");
+        b.iter(|| unsafe { resp_rs::resp3::parse_frame_unchecked(data.clone()) });
+    });
+
+    let mut wire = "*100\r\n".to_string();
+    for i in 0..100 {
+        let s = format!("value-{i:03}");
+        wire.push_str(&format!("${}\r\n{}\r\n", s.len(), s));
+    }
+    group.bench_function("resp3_array_100", |b| {
+        let data = Bytes::from(wire.clone());
+        b.iter(|| unsafe { resp_rs::resp3::parse_frame_unchecked(data.clone()) });
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "unsafe-internals")]
+criterion_group!(
+    benches,
+    bench_simple_string,
+    bench_bulk_string,
+    bench_integer,
+    bench_array_3,
+    bench_array_100,
+    bench_feature_gated,
+);
+
+#[cfg(not(feature = "unsafe-internals"))]
+criterion_group!(
+    benches,
+    bench_simple_string,
+    bench_bulk_string,
+    bench_integer,
+    bench_array_3,
+    bench_array_100,
+);
+
+criterion_main!(benches);

--- a/src/resp2.rs
+++ b/src/resp2.rs
@@ -155,6 +155,12 @@ fn parse_frame_inner(input: &Bytes, pos: usize) -> Result<(Frame, usize), ParseE
     }
 }
 
+#[cfg(feature = "unsafe-internals")]
+#[path = "resp2_unchecked.rs"]
+mod unchecked;
+#[cfg(feature = "unsafe-internals")]
+pub use unchecked::parse_frame_unchecked;
+
 /// Serialize a RESP2 frame to bytes.
 ///
 /// # Examples

--- a/src/resp2_unchecked.rs
+++ b/src/resp2_unchecked.rs
@@ -1,0 +1,195 @@
+//! Unsafe RESP2 parser that skips bounds checks for maximum performance.
+//!
+//! All functions in this module require that the input contains valid,
+//! complete RESP2 data. Passing truncated or malformed input is undefined
+//! behavior.
+
+// This entire module is unsafe-by-design. Every function operates on
+// pre-validated data with unchecked access for performance.
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use bytes::Bytes;
+
+use crate::resp2::Frame;
+
+/// Find `\r` in buf starting at `from` using unchecked pointer access.
+///
+/// # Safety
+///
+/// Caller must ensure `buf[from..]` contains a `\r` byte before the end
+/// of the allocation.
+#[inline(always)]
+unsafe fn find_cr(buf: &[u8], from: usize) -> usize {
+    let ptr = buf.as_ptr();
+    let mut i = from;
+    // SAFETY: caller guarantees a \r exists in bounds
+    while *ptr.add(i) != b'\r' {
+        i += 1;
+    }
+    i
+}
+
+/// Parse an integer from ASCII digits without bounds checks.
+///
+/// # Safety
+///
+/// Caller must ensure `buf` contains only ASCII digits (optionally preceded
+/// by `-`) and is non-empty.
+#[inline(always)]
+unsafe fn parse_i64_unchecked(buf: &[u8]) -> i64 {
+    let mut i = 0;
+    let neg = *buf.get_unchecked(0) == b'-';
+    if neg {
+        i = 1;
+    }
+    let mut v: i64 = 0;
+    while i < buf.len() {
+        v = v * 10 + (*buf.get_unchecked(i) - b'0') as i64;
+        i += 1;
+    }
+    if neg { -v } else { v }
+}
+
+/// Parse a usize from ASCII digits without bounds checks.
+///
+/// # Safety
+///
+/// Caller must ensure `buf` contains only ASCII digits and is non-empty.
+#[inline(always)]
+unsafe fn parse_usize_unchecked(buf: &[u8]) -> usize {
+    let mut v: usize = 0;
+    for i in 0..buf.len() {
+        v = v * 10 + (*buf.get_unchecked(i) - b'0') as usize;
+    }
+    v
+}
+
+/// Internal recursive parser.
+///
+/// # Safety
+///
+/// `input` must contain valid, complete RESP2 data starting at `pos`.
+unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
+    let buf = input.as_ref();
+    let tag = *buf.get_unchecked(pos);
+
+    match tag {
+        b'+' => {
+            let cr = find_cr(buf, pos + 1);
+            (Frame::SimpleString(input.slice(pos + 1..cr)), cr + 2)
+        }
+        b'-' => {
+            let cr = find_cr(buf, pos + 1);
+            (Frame::Error(input.slice(pos + 1..cr)), cr + 2)
+        }
+        b':' => {
+            let cr = find_cr(buf, pos + 1);
+            // SAFETY: valid RESP2 integer between pos+1 and cr
+            let v = parse_i64_unchecked(buf.get_unchecked(pos + 1..cr));
+            (Frame::Integer(v), cr + 2)
+        }
+        b'$' => {
+            let cr = find_cr(buf, pos + 1);
+            // SAFETY: valid RESP2 length between pos+1 and cr
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            // Null: $-1\r\n
+            if *len_slice.get_unchecked(0) == b'-' {
+                return (Frame::BulkString(None), cr + 2);
+            }
+            let len = parse_usize_unchecked(len_slice);
+            if len == 0 {
+                return (Frame::BulkString(Some(Bytes::new())), cr + 4);
+            }
+            let data_start = cr + 2;
+            let data_end = data_start + len;
+            (
+                Frame::BulkString(Some(input.slice(data_start..data_end))),
+                data_end + 2,
+            )
+        }
+        b'*' => {
+            let cr = find_cr(buf, pos + 1);
+            // SAFETY: valid RESP2 count between pos+1 and cr
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            // Null: *-1\r\n
+            if *len_slice.get_unchecked(0) == b'-' {
+                return (Frame::Array(None), cr + 2);
+            }
+            let count = parse_usize_unchecked(len_slice);
+            if count == 0 {
+                return (Frame::Array(Some(Vec::new())), cr + 2);
+            }
+            let mut cursor = cr + 2;
+            let mut items = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (frame, next) = parse_inner(input, cursor);
+                items.push(frame);
+                cursor = next;
+            }
+            (Frame::Array(Some(items)), cursor)
+        }
+        // SAFETY: caller guarantees valid RESP2, so tag must be one of the above
+        _ => std::hint::unreachable_unchecked(),
+    }
+}
+
+/// Parse a single RESP2 frame without bounds checks.
+///
+/// This is the unchecked counterpart of [`super::parse_frame`]. It produces
+/// identical `Frame` values but skips all validation for speed.
+///
+/// # Safety
+///
+/// The caller **must** guarantee that `input` contains at least one valid,
+/// complete RESP2 frame. Passing truncated, malformed, or empty input is
+/// **undefined behavior**.
+///
+/// # Examples
+///
+/// ```
+/// use bytes::Bytes;
+/// use resp_rs::resp2::{self, Frame};
+///
+/// let data = Bytes::from("+OK\r\n");
+/// // SAFETY: we know this is a valid, complete RESP2 frame.
+/// let (frame, rest) = unsafe { resp2::parse_frame_unchecked(data) };
+/// assert_eq!(frame, Frame::SimpleString(Bytes::from("OK")));
+/// assert!(rest.is_empty());
+/// ```
+pub unsafe fn parse_frame_unchecked(input: Bytes) -> (Frame, Bytes) {
+    let (frame, consumed) = parse_inner(&input, 0);
+    (frame, input.slice(consumed..))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resp2;
+
+    #[test]
+    fn unchecked_matches_safe() {
+        let cases = vec![
+            "+OK\r\n",
+            "-ERR fail\r\n",
+            ":42\r\n",
+            ":-123\r\n",
+            ":0\r\n",
+            "$5\r\nhello\r\n",
+            "$0\r\n\r\n",
+            "$-1\r\n",
+            "*0\r\n",
+            "*-1\r\n",
+            "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
+            "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n",
+            "*2\r\n*1\r\n:1\r\n+OK\r\n",
+        ];
+
+        for wire in cases {
+            let input = Bytes::from(wire);
+            let (safe_frame, safe_rest) = resp2::parse_frame(input.clone()).unwrap();
+            let (unsafe_frame, unsafe_rest) = unsafe { parse_frame_unchecked(input) };
+            assert_eq!(safe_frame, unsafe_frame, "mismatch for: {wire}");
+            assert_eq!(safe_rest, unsafe_rest, "rest mismatch for: {wire}");
+        }
+    }
+}

--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -588,6 +588,12 @@ fn parse_frame_inner(input: &Bytes, pos: usize) -> Result<(Frame, usize), ParseE
     }
 }
 
+#[cfg(feature = "unsafe-internals")]
+#[path = "resp3_unchecked.rs"]
+mod unchecked;
+#[cfg(feature = "unsafe-internals")]
+pub use unchecked::parse_frame_unchecked;
+
 /// Parse a complete RESP3 streaming sequence, accumulating chunks until termination.
 ///
 /// This function handles RESP3 streaming sequences that begin with streaming headers

--- a/src/resp3_unchecked.rs
+++ b/src/resp3_unchecked.rs
@@ -1,0 +1,289 @@
+//! Unsafe RESP3 parser that skips bounds checks for maximum performance.
+//!
+//! All functions in this module require that the input contains valid,
+//! complete RESP3 data. Passing truncated or malformed input is undefined
+//! behavior.
+
+// This entire module is unsafe-by-design. Every function operates on
+// pre-validated data with unchecked access for performance.
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use bytes::Bytes;
+
+use crate::resp3::Frame;
+
+#[inline(always)]
+unsafe fn find_cr(buf: &[u8], from: usize) -> usize {
+    let ptr = buf.as_ptr();
+    let mut i = from;
+    while *ptr.add(i) != b'\r' {
+        i += 1;
+    }
+    i
+}
+
+#[inline(always)]
+unsafe fn parse_usize_unchecked(buf: &[u8]) -> usize {
+    let mut v: usize = 0;
+    for i in 0..buf.len() {
+        v = v * 10 + (*buf.get_unchecked(i) - b'0') as usize;
+    }
+    v
+}
+
+#[inline(always)]
+unsafe fn parse_i64_unchecked(buf: &[u8]) -> i64 {
+    let mut i = 0;
+    let neg = *buf.get_unchecked(0) == b'-';
+    if neg {
+        i = 1;
+    }
+    let mut v: i64 = 0;
+    while i < buf.len() {
+        v = v * 10 + (*buf.get_unchecked(i) - b'0') as i64;
+        i += 1;
+    }
+    if neg { -v } else { v }
+}
+
+unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
+    let buf = input.as_ref();
+    let tag = *buf.get_unchecked(pos);
+
+    match tag {
+        b'+' => {
+            let cr = find_cr(buf, pos + 1);
+            (Frame::SimpleString(input.slice(pos + 1..cr)), cr + 2)
+        }
+        b'-' => {
+            let cr = find_cr(buf, pos + 1);
+            (Frame::Error(input.slice(pos + 1..cr)), cr + 2)
+        }
+        b':' => {
+            let cr = find_cr(buf, pos + 1);
+            let v = parse_i64_unchecked(buf.get_unchecked(pos + 1..cr));
+            (Frame::Integer(v), cr + 2)
+        }
+        b'$' => {
+            let cr = find_cr(buf, pos + 1);
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            if len_slice == b"?" {
+                return (Frame::StreamedStringHeader, cr + 2);
+            }
+            if *len_slice.get_unchecked(0) == b'-' {
+                return (Frame::BulkString(None), cr + 2);
+            }
+            let len = parse_usize_unchecked(len_slice);
+            if len == 0 {
+                return (Frame::BulkString(Some(Bytes::new())), cr + 4);
+            }
+            let ds = cr + 2;
+            let de = ds + len;
+            (Frame::BulkString(Some(input.slice(ds..de))), de + 2)
+        }
+        b'_' => (Frame::Null, pos + 3),
+        b',' => {
+            let cr = find_cr(buf, pos + 1);
+            let line = buf.get_unchecked(pos + 1..cr);
+            if line == b"inf" || line == b"-inf" || line == b"nan" {
+                return (Frame::SpecialFloat(input.slice(pos + 1..cr)), cr + 2);
+            }
+            let s = std::str::from_utf8_unchecked(line);
+            let v: f64 = s.parse().unwrap_unchecked();
+            (Frame::Double(v), cr + 2)
+        }
+        b'#' => {
+            let val = *buf.get_unchecked(pos + 1) == b't';
+            (Frame::Boolean(val), pos + 4)
+        }
+        b'(' => {
+            let cr = find_cr(buf, pos + 1);
+            (Frame::BigNumber(input.slice(pos + 1..cr)), cr + 2)
+        }
+        b'=' => {
+            let cr = find_cr(buf, pos + 1);
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            if len_slice == b"?" {
+                return (Frame::StreamedVerbatimStringHeader, cr + 2);
+            }
+            let len = parse_usize_unchecked(len_slice);
+            let ds = cr + 2;
+            let de = ds + len;
+            let format = input.slice(ds..ds + 3);
+            let content = input.slice(ds + 4..de);
+            (Frame::VerbatimString(format, content), de + 2)
+        }
+        b'!' => {
+            let cr = find_cr(buf, pos + 1);
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            if len_slice == b"?" {
+                return (Frame::StreamedBlobErrorHeader, cr + 2);
+            }
+            let len = parse_usize_unchecked(len_slice);
+            if len == 0 {
+                return (Frame::BlobError(Bytes::new()), cr + 4);
+            }
+            let ds = cr + 2;
+            let de = ds + len;
+            (Frame::BlobError(input.slice(ds..de)), de + 2)
+        }
+        b'*' => {
+            let cr = find_cr(buf, pos + 1);
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            if len_slice == b"?" {
+                return (Frame::StreamedArrayHeader, cr + 2);
+            }
+            if *len_slice.get_unchecked(0) == b'-' {
+                return (Frame::Array(None), cr + 2);
+            }
+            let count = parse_usize_unchecked(len_slice);
+            if count == 0 {
+                return (Frame::Array(Some(Vec::new())), cr + 2);
+            }
+            let mut cursor = cr + 2;
+            let mut items = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (frame, next) = parse_inner(input, cursor);
+                items.push(frame);
+                cursor = next;
+            }
+            (Frame::Array(Some(items)), cursor)
+        }
+        b'~' => {
+            let cr = find_cr(buf, pos + 1);
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            if len_slice == b"?" {
+                return (Frame::StreamedSetHeader, cr + 2);
+            }
+            let count = parse_usize_unchecked(len_slice);
+            let mut cursor = cr + 2;
+            let mut items = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (frame, next) = parse_inner(input, cursor);
+                items.push(frame);
+                cursor = next;
+            }
+            (Frame::Set(items), cursor)
+        }
+        b'%' | b'|' => {
+            let cr = find_cr(buf, pos + 1);
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            if len_slice == b"?" {
+                return if tag == b'%' {
+                    (Frame::StreamedMapHeader, cr + 2)
+                } else {
+                    (Frame::StreamedAttributeHeader, cr + 2)
+                };
+            }
+            let count = parse_usize_unchecked(len_slice);
+            let mut cursor = cr + 2;
+            let mut pairs = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (key, next1) = parse_inner(input, cursor);
+                let (val, next2) = parse_inner(input, next1);
+                pairs.push((key, val));
+                cursor = next2;
+            }
+            if tag == b'%' {
+                (Frame::Map(pairs), cursor)
+            } else {
+                (Frame::Attribute(pairs), cursor)
+            }
+        }
+        b'>' => {
+            let cr = find_cr(buf, pos + 1);
+            let len_slice = buf.get_unchecked(pos + 1..cr);
+            if len_slice == b"?" {
+                return (Frame::StreamedPushHeader, cr + 2);
+            }
+            let count = parse_usize_unchecked(len_slice);
+            let mut cursor = cr + 2;
+            let mut items = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (frame, next) = parse_inner(input, cursor);
+                items.push(frame);
+                cursor = next;
+            }
+            (Frame::Push(items), cursor)
+        }
+        b';' => {
+            let cr = find_cr(buf, pos + 1);
+            let len = parse_usize_unchecked(buf.get_unchecked(pos + 1..cr));
+            if len == 0 {
+                return (Frame::StreamedStringChunk(Bytes::new()), cr + 4);
+            }
+            let ds = cr + 2;
+            let de = ds + len;
+            (Frame::StreamedStringChunk(input.slice(ds..de)), de + 2)
+        }
+        b'.' => (Frame::StreamTerminator, pos + 3),
+        _ => std::hint::unreachable_unchecked(),
+    }
+}
+
+/// Parse a single RESP3 frame without bounds checks.
+///
+/// This is the unchecked counterpart of [`super::parse_frame`]. It produces
+/// identical `Frame` values but skips all validation for speed.
+///
+/// # Safety
+///
+/// The caller **must** guarantee that `input` contains at least one valid,
+/// complete RESP3 frame. Passing truncated, malformed, or empty input is
+/// **undefined behavior**.
+pub unsafe fn parse_frame_unchecked(input: Bytes) -> (Frame, Bytes) {
+    let (frame, consumed) = parse_inner(&input, 0);
+    (frame, input.slice(consumed..))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resp3;
+
+    #[test]
+    fn unchecked_matches_safe() {
+        let cases = vec![
+            "+OK\r\n",
+            "-ERR fail\r\n",
+            ":42\r\n",
+            ":-123\r\n",
+            ":0\r\n",
+            "$5\r\nhello\r\n",
+            "$0\r\n\r\n",
+            "$-1\r\n",
+            "_\r\n",
+            "#t\r\n",
+            "#f\r\n",
+            ",3.14\r\n",
+            ",inf\r\n",
+            ",-inf\r\n",
+            ",nan\r\n",
+            "(12345\r\n",
+            "=8\r\ntxt:data\r\n",
+            "!5\r\nERROR\r\n",
+            "!0\r\n\r\n",
+            "*0\r\n",
+            "*-1\r\n",
+            "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
+            "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n",
+            "~2\r\n+a\r\n+b\r\n",
+            "%1\r\n+key\r\n:1\r\n",
+            "|1\r\n+meta\r\n+val\r\n",
+            ">2\r\n+msg\r\n+data\r\n",
+            ".\r\n",
+            "$?\r\n",
+            "*?\r\n",
+            ";5\r\nhello\r\n",
+            ";0\r\n\r\n",
+        ];
+
+        for wire in cases {
+            let input = Bytes::from(wire);
+            let (safe_frame, safe_rest) = resp3::parse_frame(input.clone()).unwrap();
+            let (unsafe_frame, unsafe_rest) = unsafe { parse_frame_unchecked(input) };
+            assert_eq!(safe_frame, unsafe_frame, "mismatch for: {wire}");
+            assert_eq!(safe_rest, unsafe_rest, "rest mismatch for: {wire}");
+        }
+    }
+}

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -495,3 +495,89 @@ proptest! {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Unchecked parser property tests (feature = "unsafe-internals")
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "unsafe-internals")]
+proptest! {
+    /// Unchecked RESP2 parser must produce identical output to safe parser.
+    #[test]
+    fn resp2_unchecked_matches_safe(frame in arb_resp2_frame()) {
+        let wire = resp_rs::resp2::frame_to_bytes(&frame);
+        let (safe_frame, safe_rest) = resp_rs::resp2::parse_frame(wire.clone()).unwrap();
+        let (unsafe_frame, unsafe_rest) = unsafe {
+            resp_rs::resp2::parse_frame_unchecked(wire)
+        };
+        prop_assert_eq!(safe_frame, unsafe_frame);
+        prop_assert_eq!(safe_rest, unsafe_rest);
+    }
+
+    /// Unchecked RESP3 parser must produce identical output to safe parser.
+    #[test]
+    fn resp3_unchecked_matches_safe(frame in arb_resp3_frame()) {
+        let wire = resp_rs::resp3::frame_to_bytes(&frame);
+        let (safe_frame, safe_rest) = resp_rs::resp3::parse_frame(wire.clone()).unwrap();
+        let (unsafe_frame, unsafe_rest) = unsafe {
+            resp_rs::resp3::parse_frame_unchecked(wire)
+        };
+        prop_assert_eq!(safe_frame, unsafe_frame);
+        prop_assert_eq!(safe_rest, unsafe_rest);
+    }
+
+    /// Unchecked RESP2 pipeline must match safe pipeline.
+    #[test]
+    fn resp2_unchecked_pipeline(
+        frames in prop::collection::vec(arb_resp2_frame(), 1..8)
+    ) {
+        let mut wire = Vec::new();
+        for f in &frames {
+            wire.extend_from_slice(&resp_rs::resp2::frame_to_bytes(f));
+        }
+        let mut input = Bytes::from(wire);
+        for expected in &frames {
+            let (frame, rest) = unsafe {
+                resp_rs::resp2::parse_frame_unchecked(input)
+            };
+            prop_assert_eq!(&frame, expected);
+            input = rest;
+        }
+        prop_assert!(input.is_empty());
+    }
+
+    /// Unchecked RESP3 pipeline must match safe pipeline.
+    #[test]
+    fn resp3_unchecked_pipeline(
+        frames in prop::collection::vec(arb_resp3_frame(), 1..8)
+    ) {
+        let mut wire = Vec::new();
+        for f in &frames {
+            wire.extend_from_slice(&resp_rs::resp3::frame_to_bytes(f));
+        }
+        let mut input = Bytes::from(wire);
+        for expected in &frames {
+            let (frame, rest) = unsafe {
+                resp_rs::resp3::parse_frame_unchecked(input)
+            };
+            prop_assert_eq!(&frame, expected);
+            input = rest;
+        }
+        prop_assert!(input.is_empty());
+    }
+
+    /// Unchecked RESP3 streaming frames must match safe parser.
+    #[test]
+    fn resp3_unchecked_streaming_matches_safe(frame in arb_resp3_streaming_frame()) {
+        let wire = resp_rs::resp3::frame_to_bytes(&frame);
+
+        // parse_streaming_sequence uses parse_frame internally, but the
+        // individual frame parsing should match. Test the header + first frame.
+        let (safe_frame, safe_rest) = resp_rs::resp3::parse_frame(wire.clone()).unwrap();
+        let (unsafe_frame, unsafe_rest) = unsafe {
+            resp_rs::resp3::parse_frame_unchecked(wire)
+        };
+        prop_assert_eq!(safe_frame, unsafe_frame);
+        prop_assert_eq!(safe_rest, unsafe_rest);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `parse_frame_unchecked` for both RESP2 and RESP3, gated behind the `unsafe-internals` feature flag (not enabled by default). These produce identical `Frame` values as the safe parser but skip all bounds checks, validation, and error handling.

**Use case:** Replay of known-good data, benchmarks, pre-validated hot paths where the caller can guarantee valid, complete RESP input.

## Performance

| Benchmark | Safe | Unchecked | Speedup |
|-----------|------|-----------|---------|
| RESP2 simple_string | 12.6 ns | 9.0 ns | 1.4x |
| RESP2 array_3 (SET) | 42.7 ns | 34.1 ns | 1.3x |
| RESP3 simple_string | 39 ns | 32.9 ns | 1.2x |
| RESP3 array_3 (SET) | 83 ns | 69.8 ns | 1.2x |
| RESP3 array_100 | 1.08 us | 1.00 us | 1.1x |

The remaining gap to raw pointer parsing (1.6ns for simple string) is entirely `Bytes::slice()` atomic refcount overhead.

For reference, raw unsafe Rust with no `Bytes`/`Frame` allocation clocks in at **1.6ns for simple string** -- 2-4x faster than Redis C (5.5ns). Rust's codegen is genuinely excellent when abstractions are removed.

## Test plan

- [x] 204 tests pass with `--all-features` (106 unit + 25 property + 33 integration + 20 doc)
- [x] 196 tests pass without the feature (no regression)
- [x] Property tests verify safe/unsafe equivalence on generated frames (roundtrip, pipeline, streaming)
- [x] clippy, fmt clean