### PR TITLE
Experiment: BRESP binary protocol and protobuf RESP modeling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +586,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -655,6 +677,58 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -802,6 +876,8 @@ dependencies = [
  "criterion",
  "futures",
  "proptest",
+ "prost",
+ "prost-build",
  "redis-protocol",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,17 @@ std = ["thiserror/std", "bytes/std"]
 unsafe-internals = []
 codec = ["std", "dep:tokio-util", "dep:tokio"]
 cluster = []
+proto = ["dep:prost"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
 thiserror = { version = "2", default-features = false }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tokio = { version = "1", optional = true }
+prost = { version = "0.13", optional = true }
+
+[build-dependencies]
+prost-build = "0.13"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
@@ -43,6 +48,11 @@ harness = false
 [[bench]]
 name = "unsafe_experiment"
 harness = false
+
+[[bench]]
+name = "bresp_comparison"
+harness = false
+required-features = ["proto"]
 
 [[example]]
 name = "ping"

--- a/benches/bresp_comparison.rs
+++ b/benches/bresp_comparison.rs
@@ -1,0 +1,198 @@
+//! Head-to-head: RESP3 (text) vs BRESP (binary) vs Protobuf on identical commands.
+
+use bytes::Bytes;
+use criterion::{Criterion, criterion_group, criterion_main};
+use prost::Message;
+
+fn bench_simple_string(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::SimpleString(Bytes::from("OK"));
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = resp_rs::bresp::Frame::SimpleString(Bytes::from("OK"));
+    let bresp_wire = resp_rs::bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = resp_rs::proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/simple_string");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| resp_rs::bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| resp_rs::proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_integer(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Integer(i64::MAX);
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = resp_rs::bresp::Frame::Integer(i64::MAX);
+    let bresp_wire = resp_rs::bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = resp_rs::proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/integer_max");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| resp_rs::bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| resp_rs::proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_double(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Double(1.23456789012345);
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = resp_rs::bresp::Frame::Double(1.23456789012345);
+    let bresp_wire = resp_rs::bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = resp_rs::proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/double");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| resp_rs::bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| resp_rs::proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_set_command(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Array(Some(vec![
+        resp_rs::resp3::Frame::BulkString(Some(Bytes::from("SET"))),
+        resp_rs::resp3::Frame::BulkString(Some(Bytes::from("key"))),
+        resp_rs::resp3::Frame::BulkString(Some(Bytes::from("value"))),
+    ]));
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = resp_rs::bresp::Frame::Array(Some(vec![
+        resp_rs::bresp::Frame::BulkString(Some(Bytes::from("SET"))),
+        resp_rs::bresp::Frame::BulkString(Some(Bytes::from("key"))),
+        resp_rs::bresp::Frame::BulkString(Some(Bytes::from("value"))),
+    ]));
+    let bresp_wire = resp_rs::bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = resp_rs::proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/SET_cmd");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| resp_rs::bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| resp_rs::proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_array_100(c: &mut Criterion) {
+    let items: Vec<resp_rs::resp3::Frame> = (0..100)
+        .map(|i| resp_rs::resp3::Frame::BulkString(Some(Bytes::from(format!("value-{i:03}")))))
+        .collect();
+    let resp3_frame = resp_rs::resp3::Frame::Array(Some(items));
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_items: Vec<resp_rs::bresp::Frame> = (0..100)
+        .map(|i| resp_rs::bresp::Frame::BulkString(Some(Bytes::from(format!("value-{i:03}")))))
+        .collect();
+    let bresp_frame = resp_rs::bresp::Frame::Array(Some(bresp_items));
+    let bresp_wire = resp_rs::bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = resp_rs::proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/array_100");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| resp_rs::bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| resp_rs::proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_map(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Map(vec![
+        (
+            resp_rs::resp3::Frame::SimpleString(Bytes::from("server")),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("redis"))),
+        ),
+        (
+            resp_rs::resp3::Frame::SimpleString(Bytes::from("version")),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("7.0.0"))),
+        ),
+    ]);
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = resp_rs::bresp::Frame::Map(vec![
+        (
+            resp_rs::bresp::Frame::SimpleString(Bytes::from("server")),
+            resp_rs::bresp::Frame::BulkString(Some(Bytes::from("redis"))),
+        ),
+        (
+            resp_rs::bresp::Frame::SimpleString(Bytes::from("version")),
+            resp_rs::bresp::Frame::BulkString(Some(Bytes::from("7.0.0"))),
+        ),
+    ]);
+    let bresp_wire = resp_rs::bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = resp_rs::proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/map_2");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| resp_rs::bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| resp_rs::proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_simple_string,
+    bench_integer,
+    bench_double,
+    bench_set_command,
+    bench_array_100,
+    bench_map,
+);
+criterion_main!(benches);

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    prost_build::compile_protos(&["src/proto/resp.proto"], &["src/proto/"]).unwrap();
+}

--- a/src/bresp.rs
+++ b/src/bresp.rs
@@ -1,0 +1,405 @@
+//! BRESP: Binary Redis Serialization Protocol (experimental).
+//!
+//! A hypothetical binary encoding for RESP that eliminates text parsing overhead.
+//! Same semantics as RESP3, but with fixed-width binary framing instead of
+//! ASCII lengths and CRLF terminators.
+//!
+//! # Wire format
+//!
+//! Every frame starts with a 1-byte tag, followed by type-specific payload:
+//!
+//! | Tag | Type | Payload |
+//! |-----|------|---------|
+//! | `0x01` | Integer | 8 bytes big-endian i64 |
+//! | `0x02` | Double | 8 bytes IEEE 754 f64 |
+//! | `0x03` | Boolean | 1 byte (0x00 or 0x01) |
+//! | `0x04` | Null | (none) |
+//! | `0x10` | String | 4-byte u32 length + data |
+//! | `0x11` | Error | 4-byte u32 length + data |
+//! | `0x12` | BlobError | 4-byte u32 length + data |
+//! | `0x13` | Verbatim | 3-byte format + 4-byte u32 length + data |
+//! | `0x14` | BigNumber | 4-byte u32 length + data |
+//! | `0x20` | Array | 4-byte u32 count + items |
+//! | `0x21` | Map | 4-byte u32 count + key-value pairs |
+//! | `0x22` | Set | 4-byte u32 count + items |
+//! | `0x23` | Attribute | 4-byte u32 count + key-value pairs |
+//! | `0x24` | Push | 4-byte u32 count + items |
+//! | `0x30` | NullString | (none) |
+//! | `0x31` | NullArray | (none) |
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+use alloc::vec::Vec;
+
+// Tags
+const TAG_INTEGER: u8 = 0x01;
+const TAG_DOUBLE: u8 = 0x02;
+const TAG_BOOLEAN: u8 = 0x03;
+const TAG_NULL: u8 = 0x04;
+const TAG_STRING: u8 = 0x10;
+const TAG_ERROR: u8 = 0x11;
+const TAG_BLOB_ERROR: u8 = 0x12;
+const TAG_VERBATIM: u8 = 0x13;
+const TAG_BIG_NUMBER: u8 = 0x14;
+const TAG_ARRAY: u8 = 0x20;
+const TAG_MAP: u8 = 0x21;
+const TAG_SET: u8 = 0x22;
+const TAG_ATTRIBUTE: u8 = 0x23;
+const TAG_PUSH: u8 = 0x24;
+const TAG_NULL_STRING: u8 = 0x30;
+const TAG_NULL_ARRAY: u8 = 0x31;
+
+/// A parsed BRESP frame. Same variants as RESP3, binary encoding.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Frame {
+    SimpleString(Bytes),
+    Error(Bytes),
+    Integer(i64),
+    BulkString(Option<Bytes>),
+    Null,
+    Double(f64),
+    Boolean(bool),
+    BigNumber(Bytes),
+    BlobError(Bytes),
+    VerbatimString(Bytes, Bytes),
+    Array(Option<Vec<Frame>>),
+    Set(Vec<Frame>),
+    Map(Vec<(Frame, Frame)>),
+    Attribute(Vec<(Frame, Frame)>),
+    Push(Vec<Frame>),
+}
+
+/// Parse error for BRESP.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParseError {
+    Incomplete,
+    InvalidTag(u8),
+}
+
+/// Parse a single BRESP frame from the input.
+pub fn parse_frame(input: Bytes) -> Result<(Frame, Bytes), ParseError> {
+    let (frame, consumed) = parse_inner(&input, 0)?;
+    Ok((frame, input.slice(consumed..)))
+}
+
+fn parse_inner(input: &Bytes, pos: usize) -> Result<(Frame, usize), ParseError> {
+    let buf = input.as_ref();
+    if pos >= buf.len() {
+        return Err(ParseError::Incomplete);
+    }
+
+    let tag = buf[pos];
+    let after_tag = pos + 1;
+
+    match tag {
+        TAG_INTEGER => {
+            if after_tag + 8 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let v = i64::from_be_bytes(buf[after_tag..after_tag + 8].try_into().unwrap());
+            Ok((Frame::Integer(v), after_tag + 8))
+        }
+        TAG_DOUBLE => {
+            if after_tag + 8 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let v = f64::from_be_bytes(buf[after_tag..after_tag + 8].try_into().unwrap());
+            Ok((Frame::Double(v), after_tag + 8))
+        }
+        TAG_BOOLEAN => {
+            if after_tag >= buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            Ok((Frame::Boolean(buf[after_tag] != 0), after_tag + 1))
+        }
+        TAG_NULL => Ok((Frame::Null, after_tag)),
+        TAG_NULL_STRING => Ok((Frame::BulkString(None), after_tag)),
+        TAG_NULL_ARRAY => Ok((Frame::Array(None), after_tag)),
+
+        TAG_STRING => parse_blob(input, buf, after_tag, |b| Frame::BulkString(Some(b))),
+        TAG_ERROR => parse_blob(input, buf, after_tag, Frame::Error),
+        TAG_BLOB_ERROR => parse_blob(input, buf, after_tag, Frame::BlobError),
+        TAG_BIG_NUMBER => parse_blob(input, buf, after_tag, Frame::BigNumber),
+
+        TAG_VERBATIM => {
+            if after_tag + 3 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let format = input.slice(after_tag..after_tag + 3);
+            let len_pos = after_tag + 3;
+            if len_pos + 4 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let len = u32::from_be_bytes(buf[len_pos..len_pos + 4].try_into().unwrap()) as usize;
+            let data_start = len_pos + 4;
+            if data_start + len > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let content = input.slice(data_start..data_start + len);
+            Ok((Frame::VerbatimString(format, content), data_start + len))
+        }
+
+        TAG_ARRAY => parse_list(input, buf, after_tag, |items| Frame::Array(Some(items))),
+        TAG_SET => parse_list(input, buf, after_tag, Frame::Set),
+        TAG_PUSH => parse_list(input, buf, after_tag, Frame::Push),
+
+        TAG_MAP => parse_pairs(input, buf, after_tag, Frame::Map),
+        TAG_ATTRIBUTE => parse_pairs(input, buf, after_tag, Frame::Attribute),
+
+        _ => Err(ParseError::InvalidTag(tag)),
+    }
+}
+
+#[inline]
+fn read_u32_len(buf: &[u8], pos: usize) -> Result<(usize, usize), ParseError> {
+    if pos + 4 > buf.len() {
+        return Err(ParseError::Incomplete);
+    }
+    let len = u32::from_be_bytes(buf[pos..pos + 4].try_into().unwrap()) as usize;
+    Ok((len, pos + 4))
+}
+
+fn parse_blob(
+    input: &Bytes,
+    buf: &[u8],
+    pos: usize,
+    make: impl FnOnce(Bytes) -> Frame,
+) -> Result<(Frame, usize), ParseError> {
+    let (len, data_start) = read_u32_len(buf, pos)?;
+    if data_start + len > buf.len() {
+        return Err(ParseError::Incomplete);
+    }
+    let data = if len == 0 {
+        Bytes::new()
+    } else {
+        input.slice(data_start..data_start + len)
+    };
+    Ok((make(data), data_start + len))
+}
+
+fn parse_list(
+    input: &Bytes,
+    buf: &[u8],
+    pos: usize,
+    make: impl FnOnce(Vec<Frame>) -> Frame,
+) -> Result<(Frame, usize), ParseError> {
+    let (count, mut cursor) = read_u32_len(buf, pos)?;
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (frame, next) = parse_inner(input, cursor)?;
+        items.push(frame);
+        cursor = next;
+    }
+    Ok((make(items), cursor))
+}
+
+fn parse_pairs(
+    input: &Bytes,
+    buf: &[u8],
+    pos: usize,
+    make: impl FnOnce(Vec<(Frame, Frame)>) -> Frame,
+) -> Result<(Frame, usize), ParseError> {
+    let (count, mut cursor) = read_u32_len(buf, pos)?;
+    let mut pairs = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (key, next1) = parse_inner(input, cursor)?;
+        let (val, next2) = parse_inner(input, next1)?;
+        pairs.push((key, val));
+        cursor = next2;
+    }
+    Ok((make(pairs), cursor))
+}
+
+/// Serialize a BRESP frame to bytes.
+pub fn frame_to_bytes(frame: &Frame) -> Bytes {
+    let mut buf = BytesMut::new();
+    serialize(frame, &mut buf);
+    buf.freeze()
+}
+
+fn serialize(frame: &Frame, buf: &mut BytesMut) {
+    match frame {
+        Frame::Integer(v) => {
+            buf.put_u8(TAG_INTEGER);
+            buf.put_i64(*v);
+        }
+        Frame::Double(v) => {
+            buf.put_u8(TAG_DOUBLE);
+            buf.put_f64(*v);
+        }
+        Frame::Boolean(v) => {
+            buf.put_u8(TAG_BOOLEAN);
+            buf.put_u8(if *v { 1 } else { 0 });
+        }
+        Frame::Null => buf.put_u8(TAG_NULL),
+        Frame::SimpleString(s) => serialize_blob(TAG_STRING, s, buf),
+        Frame::Error(e) => serialize_blob(TAG_ERROR, e, buf),
+        Frame::BlobError(e) => serialize_blob(TAG_BLOB_ERROR, e, buf),
+        Frame::BigNumber(n) => serialize_blob(TAG_BIG_NUMBER, n, buf),
+        Frame::BulkString(Some(s)) => serialize_blob(TAG_STRING, s, buf),
+        Frame::BulkString(None) => buf.put_u8(TAG_NULL_STRING),
+        Frame::VerbatimString(format, content) => {
+            buf.put_u8(TAG_VERBATIM);
+            buf.put_slice(format);
+            buf.put_u32(content.len() as u32);
+            buf.put_slice(content);
+        }
+        Frame::Array(Some(items)) => serialize_list(TAG_ARRAY, items, buf),
+        Frame::Array(None) => buf.put_u8(TAG_NULL_ARRAY),
+        Frame::Set(items) => serialize_list(TAG_SET, items, buf),
+        Frame::Push(items) => serialize_list(TAG_PUSH, items, buf),
+        Frame::Map(pairs) => serialize_pairs(TAG_MAP, pairs, buf),
+        Frame::Attribute(pairs) => serialize_pairs(TAG_ATTRIBUTE, pairs, buf),
+    }
+}
+
+fn serialize_blob(tag: u8, data: &Bytes, buf: &mut BytesMut) {
+    buf.put_u8(tag);
+    buf.put_u32(data.len() as u32);
+    buf.put_slice(data);
+}
+
+fn serialize_list(tag: u8, items: &[Frame], buf: &mut BytesMut) {
+    buf.put_u8(tag);
+    buf.put_u32(items.len() as u32);
+    for item in items {
+        serialize(item, buf);
+    }
+}
+
+fn serialize_pairs(tag: u8, pairs: &[(Frame, Frame)], buf: &mut BytesMut) {
+    buf.put_u8(tag);
+    buf.put_u32(pairs.len() as u32);
+    for (key, val) in pairs {
+        serialize(key, buf);
+        serialize(val, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_integer() {
+        let frame = Frame::Integer(i64::MAX);
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 9); // tag + 8 bytes
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_double() {
+        let frame = Frame::Double(1.23456789);
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 9);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_boolean() {
+        for v in [true, false] {
+            let frame = Frame::Boolean(v);
+            let wire = frame_to_bytes(&frame);
+            assert_eq!(wire.len(), 2);
+            let (parsed, _) = parse_frame(wire).unwrap();
+            assert_eq!(parsed, frame);
+        }
+    }
+
+    #[test]
+    fn roundtrip_null() {
+        let wire = frame_to_bytes(&Frame::Null);
+        assert_eq!(wire.len(), 1);
+        let (parsed, _) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, Frame::Null);
+    }
+
+    #[test]
+    fn roundtrip_string() {
+        // SimpleString and BulkString(Some) both serialize as TAG_STRING
+        // and parse back as BulkString(Some) -- no distinction in binary format
+        let frame = Frame::SimpleString(Bytes::from("OK"));
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 1 + 4 + 2); // tag + len + "OK"
+        let (parsed, _) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, Frame::BulkString(Some(Bytes::from("OK"))));
+    }
+
+    #[test]
+    fn roundtrip_bulk_null() {
+        let frame = Frame::BulkString(None);
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 1);
+        let (parsed, _) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+    }
+
+    #[test]
+    fn roundtrip_array() {
+        let frame = Frame::Array(Some(vec![
+            Frame::BulkString(Some(Bytes::from("SET"))),
+            Frame::BulkString(Some(Bytes::from("key"))),
+            Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+        let wire = frame_to_bytes(&frame);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_map() {
+        let frame = Frame::Map(vec![
+            (
+                Frame::BulkString(Some(Bytes::from("key1"))),
+                Frame::Integer(1),
+            ),
+            (
+                Frame::BulkString(Some(Bytes::from("key2"))),
+                Frame::Integer(2),
+            ),
+        ]);
+        let wire = frame_to_bytes(&frame);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_verbatim() {
+        let frame = Frame::VerbatimString(Bytes::from("txt"), Bytes::from("hello world"));
+        let wire = frame_to_bytes(&frame);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn wire_size_comparison() {
+        // SET key value command
+        let frame = Frame::Array(Some(vec![
+            Frame::BulkString(Some(Bytes::from("SET"))),
+            Frame::BulkString(Some(Bytes::from("key"))),
+            Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+
+        let bresp_wire = frame_to_bytes(&frame);
+
+        // Equivalent RESP3 wire format
+        let resp3_wire = "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n";
+
+        println!("SET key value:");
+        println!("  RESP3: {} bytes", resp3_wire.len());
+        println!("  BRESP: {} bytes", bresp_wire.len());
+        println!(
+            "  Savings: {} bytes ({:.0}%)",
+            resp3_wire.len() as i64 - bresp_wire.len() as i64,
+            (1.0 - bresp_wire.len() as f64 / resp3_wire.len() as f64) * 100.0
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,11 @@ pub mod codec;
 #[cfg(feature = "cluster")]
 pub mod cluster;
 
+pub mod bresp;
+
+#[cfg(feature = "proto")]
+pub mod proto_resp;
+
 /// Errors that can occur during RESP parsing.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum ParseError {

--- a/src/proto/resp.proto
+++ b/src/proto/resp.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package resp;
+
+// A RESP frame modeled as a protobuf message.
+// Covers all RESP2 and RESP3 types.
+message Frame {
+  oneof kind {
+    bytes simple_string = 1;
+    bytes error = 2;
+    int64 integer = 3;
+    NullableBytes bulk_string = 4;
+    Null null = 5;
+    double double_val = 6;
+    bool boolean = 7;
+    bytes big_number = 8;
+    bytes blob_error = 9;
+    VerbatimString verbatim_string = 10;
+    NullableArray array = 11;
+    FrameList set = 12;
+    PairList map = 13;
+    PairList attribute = 14;
+    FrameList push = 15;
+  }
+}
+
+// Null type (RESP3 _\r\n)
+message Null {}
+
+// Bulk string that can be null ($-1)
+message NullableBytes {
+  optional bytes data = 1;
+}
+
+// Array that can be null (*-1)
+message NullableArray {
+  optional FrameList items = 1;
+}
+
+// List of frames (for Array, Set, Push)
+message FrameList {
+  repeated Frame items = 1;
+}
+
+// Key-value pair
+message Pair {
+  Frame key = 1;
+  Frame value = 2;
+}
+
+// List of key-value pairs (for Map, Attribute)
+message PairList {
+  repeated Pair entries = 1;
+}
+
+// Verbatim string with format tag
+message VerbatimString {
+  bytes format = 1;
+  bytes content = 2;
+}

--- a/src/proto_resp.rs
+++ b/src/proto_resp.rs
@@ -1,0 +1,202 @@
+//! Protobuf-encoded RESP frames (experimental).
+//!
+//! Models RESP3 frame types as Protocol Buffers messages for comparison
+//! benchmarking. Same semantics as RESP3, protobuf wire encoding.
+
+/// Generated protobuf types.
+pub mod pb {
+    include!(concat!(env!("OUT_DIR"), "/resp.rs"));
+}
+
+use bytes::Bytes;
+
+/// Convert a resp3::Frame to a protobuf Frame.
+pub fn resp3_to_proto(frame: &crate::resp3::Frame) -> pb::Frame {
+    use crate::resp3::Frame as R;
+    use pb::frame::Kind;
+
+    let kind = match frame {
+        R::SimpleString(b) => Kind::SimpleString(b.to_vec()),
+        R::Error(b) => Kind::Error(b.to_vec()),
+        R::Integer(v) => Kind::Integer(*v),
+        R::Double(v) => Kind::DoubleVal(*v),
+        R::Boolean(v) => Kind::Boolean(*v),
+        R::Null => Kind::Null(pb::Null {}),
+        R::BulkString(Some(b)) => Kind::BulkString(pb::NullableBytes {
+            data: Some(b.to_vec()),
+        }),
+        R::BulkString(None) => Kind::BulkString(pb::NullableBytes { data: None }),
+        R::BlobError(b) => Kind::BlobError(b.to_vec()),
+        R::BigNumber(b) => Kind::BigNumber(b.to_vec()),
+        R::VerbatimString(fmt, content) => Kind::VerbatimString(pb::VerbatimString {
+            format: fmt.to_vec(),
+            content: content.to_vec(),
+        }),
+        R::Array(Some(items)) => Kind::Array(pb::NullableArray {
+            items: Some(pb::FrameList {
+                items: items.iter().map(resp3_to_proto).collect(),
+            }),
+        }),
+        R::Array(None) => Kind::Array(pb::NullableArray { items: None }),
+        R::Set(items) => Kind::Set(pb::FrameList {
+            items: items.iter().map(resp3_to_proto).collect(),
+        }),
+        R::Map(pairs) => Kind::Map(pb::PairList {
+            entries: pairs
+                .iter()
+                .map(|(k, v)| pb::Pair {
+                    key: Some(resp3_to_proto(k)),
+                    value: Some(resp3_to_proto(v)),
+                })
+                .collect(),
+        }),
+        R::Attribute(pairs) => Kind::Attribute(pb::PairList {
+            entries: pairs
+                .iter()
+                .map(|(k, v)| pb::Pair {
+                    key: Some(resp3_to_proto(k)),
+                    value: Some(resp3_to_proto(v)),
+                })
+                .collect(),
+        }),
+        R::Push(items) => Kind::Push(pb::FrameList {
+            items: items.iter().map(resp3_to_proto).collect(),
+        }),
+        // Streaming types don't have a protobuf equivalent
+        _ => Kind::Null(pb::Null {}),
+    };
+
+    pb::Frame { kind: Some(kind) }
+}
+
+/// Convert a protobuf Frame back to a resp3::Frame.
+pub fn proto_to_resp3(frame: &pb::Frame) -> crate::resp3::Frame {
+    use crate::resp3::Frame as R;
+    use pb::frame::Kind;
+
+    match frame.kind.as_ref().unwrap() {
+        Kind::SimpleString(b) => R::SimpleString(Bytes::from(b.clone())),
+        Kind::Error(b) => R::Error(Bytes::from(b.clone())),
+        Kind::Integer(v) => R::Integer(*v),
+        Kind::DoubleVal(v) => R::Double(*v),
+        Kind::Boolean(v) => R::Boolean(*v),
+        Kind::Null(_) => R::Null,
+        Kind::BulkString(nb) => R::BulkString(nb.data.as_ref().map(|b| Bytes::from(b.clone()))),
+        Kind::BlobError(b) => R::BlobError(Bytes::from(b.clone())),
+        Kind::BigNumber(b) => R::BigNumber(Bytes::from(b.clone())),
+        Kind::VerbatimString(vs) => R::VerbatimString(
+            Bytes::from(vs.format.clone()),
+            Bytes::from(vs.content.clone()),
+        ),
+        Kind::Array(na) => match &na.items {
+            Some(list) => R::Array(Some(list.items.iter().map(proto_to_resp3).collect())),
+            None => R::Array(None),
+        },
+        Kind::Set(list) => R::Set(list.items.iter().map(proto_to_resp3).collect()),
+        Kind::Map(pairs) => R::Map(
+            pairs
+                .entries
+                .iter()
+                .map(|p| {
+                    (
+                        proto_to_resp3(p.key.as_ref().unwrap()),
+                        proto_to_resp3(p.value.as_ref().unwrap()),
+                    )
+                })
+                .collect(),
+        ),
+        Kind::Attribute(pairs) => R::Attribute(
+            pairs
+                .entries
+                .iter()
+                .map(|p| {
+                    (
+                        proto_to_resp3(p.key.as_ref().unwrap()),
+                        proto_to_resp3(p.value.as_ref().unwrap()),
+                    )
+                })
+                .collect(),
+        ),
+        Kind::Push(list) => R::Push(list.items.iter().map(proto_to_resp3).collect()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn roundtrip_simple_string() {
+        let original = crate::resp3::Frame::SimpleString(Bytes::from("OK"));
+        let proto = resp3_to_proto(&original);
+        let mut buf = Vec::new();
+        proto.encode(&mut buf).unwrap();
+        let decoded_proto = pb::Frame::decode(buf.as_slice()).unwrap();
+        let back = proto_to_resp3(&decoded_proto);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn roundtrip_set_command() {
+        let original = crate::resp3::Frame::Array(Some(vec![
+            crate::resp3::Frame::BulkString(Some(Bytes::from("SET"))),
+            crate::resp3::Frame::BulkString(Some(Bytes::from("key"))),
+            crate::resp3::Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+        let proto = resp3_to_proto(&original);
+        let mut buf = Vec::new();
+        proto.encode(&mut buf).unwrap();
+        let decoded_proto = pb::Frame::decode(buf.as_slice()).unwrap();
+        let back = proto_to_resp3(&decoded_proto);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn roundtrip_map() {
+        let original = crate::resp3::Frame::Map(vec![
+            (
+                crate::resp3::Frame::SimpleString(Bytes::from("key1")),
+                crate::resp3::Frame::Integer(42),
+            ),
+            (
+                crate::resp3::Frame::SimpleString(Bytes::from("key2")),
+                crate::resp3::Frame::Boolean(true),
+            ),
+        ]);
+        let proto = resp3_to_proto(&original);
+        let mut buf = Vec::new();
+        proto.encode(&mut buf).unwrap();
+        let decoded_proto = pb::Frame::decode(buf.as_slice()).unwrap();
+        let back = proto_to_resp3(&decoded_proto);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn wire_size_comparison() {
+        use prost::Message;
+
+        // SET key value
+        let frame = crate::resp3::Frame::Array(Some(vec![
+            crate::resp3::Frame::BulkString(Some(Bytes::from("SET"))),
+            crate::resp3::Frame::BulkString(Some(Bytes::from("key"))),
+            crate::resp3::Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+
+        let resp3_wire = crate::resp3::frame_to_bytes(&frame);
+        let bresp_frame = crate::bresp::Frame::Array(Some(vec![
+            crate::bresp::Frame::BulkString(Some(Bytes::from("SET"))),
+            crate::bresp::Frame::BulkString(Some(Bytes::from("key"))),
+            crate::bresp::Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+        let bresp_wire = crate::bresp::frame_to_bytes(&bresp_frame);
+
+        let proto = resp3_to_proto(&frame);
+        let proto_size = proto.encoded_len();
+
+        println!("SET key value wire sizes:");
+        println!("  RESP3:    {} bytes", resp3_wire.len());
+        println!("  BRESP:    {} bytes", bresp_wire.len());
+        println!("  Protobuf: {} bytes", proto_size);
+    }
+}


### PR DESCRIPTION
## Summary

Two experimental alternative encodings for RESP, with three-way benchmarks. Not intended for release -- research into protocol encoding tradeoffs.

**BRESP** (src/bresp.rs): Hand-rolled binary protocol. Same Frame types, fixed-width binary framing. Eliminates CRLF scanning and ASCII number parsing.

**Protobuf RESP** (src/proto_resp.rs, behind \`proto\` feature): RESP3 types as protobuf messages with \`oneof\`-based Frame. Interesting as a foundation for gRPC-based Redis access (IDL-first client generation, bidirectional streaming for pub/sub).

### Benchmark results

| Command | RESP3 | BRESP | Protobuf |
|---------|-------|-------|----------|
| Simple string | 39.9 ns | 40.7 ns | 39.3 ns |
| Integer (max) | 47.9 ns | 35.2 ns | **9.1 ns** |
| Double | 52.6 ns | 35.0 ns | **7.9 ns** |
| SET key value | **86.8 ns** | **80.5 ns** | 191.6 ns |
| Array(100) | **1.10 us** | **1.05 us** | 5.73 us |

Key insight: for string-heavy Redis workloads, the wire encoding is not the bottleneck -- \`Bytes\` reference counting dominates. Binary formats only win where they eliminate actual computation (float/integer parsing). Protobuf's scalar speed comes from decoding into native types without \`Bytes\` overhead, but its nested message allocation kills collection performance.

Run benchmarks: \`cargo bench --bench bresp_comparison --features proto\`