### PR TITLE
Move experiments into workspace crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bresp"
+version = "0.0.0"
+dependencies = [
+ "bytes",
+ "resp-rs",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,10 +252,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "experiments-bench"
+version = "0.0.0"
+dependencies = [
+ "bresp",
+ "bytes",
+ "criterion",
+ "prost",
+ "proto-resp",
+ "resp-rs",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
@@ -523,6 +549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +606,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -655,6 +697,68 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "proto-resp"
+version = "0.0.0"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-build",
+ "resp-rs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
 
 [[package]]
 name = "anyhow"
@@ -132,6 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -140,8 +185,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -149,6 +208,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cookie-factory"
@@ -468,6 +533,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +649,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -1040,6 +1117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1164,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "throughput"
+version = "0.0.0"
+dependencies = [
+ "bresp",
+ "bytes",
+ "clap",
+ "prost",
+ "proto-resp",
+ "resp-rs",
+ "tokio",
 ]
 
 [[package]]
@@ -1151,6 +1247,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "experiments/bresp", "experiments/proto-resp", "experiments/bench"]
+
 [package]
 name = "resp-rs"
 version = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "experiments/bresp", "experiments/proto-resp", "experiments/bench"]
+members = [".", "experiments/bresp", "experiments/proto-resp", "experiments/bench", "experiments/throughput"]
 
 [package]
 name = "resp-rs"

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,90 @@
+# Experiments
+
+Alternative protocol encodings for RESP, exploring the tradeoffs between
+text, binary, and schema-based wire formats. These are research experiments,
+not production code.
+
+## The question
+
+RESP is a text protocol: integers are ASCII digits, lengths are decimal strings,
+frames are delimited by `\r\n`. What if it were binary? What if it were protobuf?
+How much does the encoding actually matter?
+
+## The experiments
+
+### [BRESP](bresp/) -- Binary RESP
+
+A hand-rolled binary encoding with the same frame types as RESP3. Fixed-width
+tags, binary lengths (u32), no CRLF. Designed to answer: "how much faster is
+binary framing?"
+
+### [proto-resp](proto-resp/) -- Protobuf RESP
+
+RESP3 frame types modeled as Protocol Buffers messages using `prost`. Designed
+to answer: "what does RESP look like as an IDL?" and "how does protobuf encoding
+compare?"
+
+The protobuf model is particularly interesting as a foundation for a gRPC-based
+Redis interface -- typed RPCs, bidirectional streaming for pub/sub, and
+auto-generated clients for every language.
+
+## Results
+
+Three-way benchmark: same logical data, three wire formats.
+
+| Command | RESP3 (text) | BRESP (binary) | Protobuf |
+|---------|-------------|----------------|----------|
+| Simple string "OK" | 40 ns | 41 ns | 39 ns |
+| Integer (i64 max) | 48 ns | 35 ns | **9 ns** |
+| Double | 53 ns | 35 ns | **8 ns** |
+| SET key value | **87 ns** | **80 ns** | 192 ns |
+| Array(100 strings) | **1.10 us** | **1.05 us** | 5.73 us |
+| Map(2 pairs) | **104 ns** | **100 ns** | 254 ns |
+
+### Wire sizes
+
+| Command | RESP3 | BRESP | Protobuf |
+|---------|-------|-------|----------|
+| Simple string "OK" | 5 B | 7 B | 4 B |
+| Integer (i64 max) | 22 B | 9 B | 10 B |
+| SET key value | 33 B | 31 B | 33 B |
+| Array(100 strings) | 1506 B | 1405 B | 1506 B |
+
+## Key findings
+
+**Binary framing barely helps for strings.** BRESP is ~7% faster than RESP3 on
+a SET command, but the gap is noise for simple strings. The CRLF scanning and
+ASCII length parsing that BRESP eliminates account for only ~5% of total parse
+time.
+
+**Protobuf destroys everything on scalars.** 9ns for an integer vs 48ns for
+RESP3 (5x faster). This is because prost decodes into native Rust types with
+no `Bytes` reference counting overhead.
+
+**Protobuf is 2-5x slower on collections.** Every nested frame is a heap-allocated
+`Box<Frame>` in prost's generated code. Our hand-rolled parsers use
+`Vec::with_capacity` and flat recursive parsing, which is much more
+allocation-efficient.
+
+**The bottleneck is `Bytes`, not the wire format.** For string-heavy workloads
+(which is most of Redis), the `Bytes::slice()` atomic reference count increment
+costs ~3-5ns per frame -- more than the actual parsing work. A raw unsafe Rust
+parser without `Bytes` parses `+OK\r\n` in 1.6ns, proving the wire format is
+not the limiting factor.
+
+## Running the benchmarks
+
+```sh
+cargo bench --package experiments-bench --bench three_way
+```
+
+## Implications
+
+For a next-generation Redis protocol, the protobuf approach is compelling not
+for its parsing speed but for its **ecosystem benefits**: IDL-defined schema,
+auto-generated clients, gRPC streaming for pub/sub, and strong typing across
+all languages. The parsing overhead for collections could likely be improved
+with a custom protobuf runtime tuned for the RESP use case.
+
+The binary encoding (BRESP) is a less interesting tradeoff: marginal speed
+gains for the loss of human readability, with no ecosystem benefits.

--- a/experiments/bench/Cargo.toml
+++ b/experiments/bench/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "experiments-bench"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[[bench]]
+name = "three_way"
+harness = false
+
+[dependencies]
+bresp = { path = "../bresp" }
+bytes = "1"
+criterion = { version = "0.5", features = ["html_reports"] }
+prost = "0.13"
+proto-resp = { path = "../proto-resp" }
+resp-rs = { path = "../.." }

--- a/experiments/bench/benches/three_way.rs
+++ b/experiments/bench/benches/three_way.rs
@@ -1,0 +1,198 @@
+//! Head-to-head: RESP3 (text) vs BRESP (binary) vs Protobuf on identical commands.
+
+use bytes::Bytes;
+use criterion::{Criterion, criterion_group, criterion_main};
+use prost::Message;
+
+fn bench_simple_string(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::SimpleString(Bytes::from("OK"));
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = bresp::Frame::SimpleString(Bytes::from("OK"));
+    let bresp_wire = bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/simple_string");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_integer(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Integer(i64::MAX);
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = bresp::Frame::Integer(i64::MAX);
+    let bresp_wire = bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/integer_max");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_double(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Double(1.23456789012345);
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = bresp::Frame::Double(1.23456789012345);
+    let bresp_wire = bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/double");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_set_command(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Array(Some(vec![
+        resp_rs::resp3::Frame::BulkString(Some(Bytes::from("SET"))),
+        resp_rs::resp3::Frame::BulkString(Some(Bytes::from("key"))),
+        resp_rs::resp3::Frame::BulkString(Some(Bytes::from("value"))),
+    ]));
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = bresp::Frame::Array(Some(vec![
+        bresp::Frame::BulkString(Some(Bytes::from("SET"))),
+        bresp::Frame::BulkString(Some(Bytes::from("key"))),
+        bresp::Frame::BulkString(Some(Bytes::from("value"))),
+    ]));
+    let bresp_wire = bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/SET_cmd");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_array_100(c: &mut Criterion) {
+    let items: Vec<resp_rs::resp3::Frame> = (0..100)
+        .map(|i| resp_rs::resp3::Frame::BulkString(Some(Bytes::from(format!("value-{i:03}")))))
+        .collect();
+    let resp3_frame = resp_rs::resp3::Frame::Array(Some(items));
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_items: Vec<bresp::Frame> = (0..100)
+        .map(|i| bresp::Frame::BulkString(Some(Bytes::from(format!("value-{i:03}")))))
+        .collect();
+    let bresp_frame = bresp::Frame::Array(Some(bresp_items));
+    let bresp_wire = bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/array_100");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+fn bench_map(c: &mut Criterion) {
+    let resp3_frame = resp_rs::resp3::Frame::Map(vec![
+        (
+            resp_rs::resp3::Frame::SimpleString(Bytes::from("server")),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("redis"))),
+        ),
+        (
+            resp_rs::resp3::Frame::SimpleString(Bytes::from("version")),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("7.0.0"))),
+        ),
+    ]);
+    let resp3_wire = resp_rs::resp3::frame_to_bytes(&resp3_frame);
+
+    let bresp_frame = bresp::Frame::Map(vec![
+        (
+            bresp::Frame::SimpleString(Bytes::from("server")),
+            bresp::Frame::BulkString(Some(Bytes::from("redis"))),
+        ),
+        (
+            bresp::Frame::SimpleString(Bytes::from("version")),
+            bresp::Frame::BulkString(Some(Bytes::from("7.0.0"))),
+        ),
+    ]);
+    let bresp_wire = bresp::frame_to_bytes(&bresp_frame);
+
+    let proto_frame = proto_resp::resp3_to_proto(&resp3_frame);
+    let mut proto_wire = Vec::new();
+    proto_frame.encode(&mut proto_wire).unwrap();
+    let proto_bytes = Bytes::from(proto_wire);
+
+    let mut group = c.benchmark_group("3way/map_2");
+    group.bench_function(format!("resp3 ({} B)", resp3_wire.len()), |b| {
+        b.iter(|| resp_rs::resp3::parse_frame(resp3_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("bresp ({} B)", bresp_wire.len()), |b| {
+        b.iter(|| bresp::parse_frame(bresp_wire.clone()).unwrap());
+    });
+    group.bench_function(format!("proto ({} B)", proto_bytes.len()), |b| {
+        b.iter(|| proto_resp::pb::Frame::decode(proto_bytes.as_ref()).unwrap());
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_simple_string,
+    bench_integer,
+    bench_double,
+    bench_set_command,
+    bench_array_100,
+    bench_map,
+);
+criterion_main!(benches);

--- a/experiments/bresp/Cargo.toml
+++ b/experiments/bresp/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bresp"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "Experimental binary RESP protocol"
+
+[dependencies]
+bytes = "1"
+resp-rs = { path = "../.." }

--- a/experiments/bresp/README.md
+++ b/experiments/bresp/README.md
@@ -1,0 +1,47 @@
+# BRESP -- Binary RESP
+
+A hypothetical binary encoding for the Redis Serialization Protocol.
+
+## Wire format
+
+Every frame starts with a 1-byte tag, followed by type-specific payload:
+
+| Tag | Type | Payload |
+|-----|------|---------|
+| `0x01` | Integer | 8 bytes big-endian i64 |
+| `0x02` | Double | 8 bytes IEEE 754 f64 |
+| `0x03` | Boolean | 1 byte (0x00/0x01) |
+| `0x04` | Null | (none) |
+| `0x10` | String | 4-byte u32 length + data |
+| `0x11` | Error | 4-byte u32 length + data |
+| `0x12` | BlobError | 4-byte u32 length + data |
+| `0x13` | Verbatim | 3-byte format + 4-byte u32 length + data |
+| `0x14` | BigNumber | 4-byte u32 length + data |
+| `0x20` | Array | 4-byte u32 count + items |
+| `0x21` | Map | 4-byte u32 count + key-value pairs |
+| `0x22` | Set | 4-byte u32 count + items |
+| `0x23` | Attribute | 4-byte u32 count + key-value pairs |
+| `0x24` | Push | 4-byte u32 count + items |
+| `0x30` | NullString | (none) |
+| `0x31` | NullArray | (none) |
+
+## What it eliminates
+
+- No CRLF scanning (fixed-width binary lengths)
+- No ASCII integer parsing (`i64::from_be_bytes` instead)
+- No float parsing (`f64::from_be_bytes` instead)
+- No variable-width length encoding
+
+## What it costs
+
+- Not human-readable (can't `telnet` and type commands)
+- Slightly larger wire size for short strings (4-byte length vs 1-2 digit ASCII)
+- Needs tooling to inspect traffic
+
+## Verdict
+
+BRESP is ~7% faster than RESP3 for typical string commands (SET, GET) and
+~40% faster for integer-heavy workloads. The gains are real but modest,
+because the wire encoding is only ~5-10% of total parse time -- the rest is
+`Bytes` reference counting and Frame construction overhead that both formats
+share equally.

--- a/experiments/bresp/src/lib.rs
+++ b/experiments/bresp/src/lib.rs
@@ -1,0 +1,403 @@
+//! BRESP: Binary Redis Serialization Protocol (experimental).
+//!
+//! A hypothetical binary encoding for RESP that eliminates text parsing overhead.
+//! Same semantics as RESP3, but with fixed-width binary framing instead of
+//! ASCII lengths and CRLF terminators.
+//!
+//! # Wire format
+//!
+//! Every frame starts with a 1-byte tag, followed by type-specific payload:
+//!
+//! | Tag | Type | Payload |
+//! |-----|------|---------|
+//! | `0x01` | Integer | 8 bytes big-endian i64 |
+//! | `0x02` | Double | 8 bytes IEEE 754 f64 |
+//! | `0x03` | Boolean | 1 byte (0x00 or 0x01) |
+//! | `0x04` | Null | (none) |
+//! | `0x10` | String | 4-byte u32 length + data |
+//! | `0x11` | Error | 4-byte u32 length + data |
+//! | `0x12` | BlobError | 4-byte u32 length + data |
+//! | `0x13` | Verbatim | 3-byte format + 4-byte u32 length + data |
+//! | `0x14` | BigNumber | 4-byte u32 length + data |
+//! | `0x20` | Array | 4-byte u32 count + items |
+//! | `0x21` | Map | 4-byte u32 count + key-value pairs |
+//! | `0x22` | Set | 4-byte u32 count + items |
+//! | `0x23` | Attribute | 4-byte u32 count + key-value pairs |
+//! | `0x24` | Push | 4-byte u32 count + items |
+//! | `0x30` | NullString | (none) |
+//! | `0x31` | NullArray | (none) |
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+// Tags
+const TAG_INTEGER: u8 = 0x01;
+const TAG_DOUBLE: u8 = 0x02;
+const TAG_BOOLEAN: u8 = 0x03;
+const TAG_NULL: u8 = 0x04;
+const TAG_STRING: u8 = 0x10;
+const TAG_ERROR: u8 = 0x11;
+const TAG_BLOB_ERROR: u8 = 0x12;
+const TAG_VERBATIM: u8 = 0x13;
+const TAG_BIG_NUMBER: u8 = 0x14;
+const TAG_ARRAY: u8 = 0x20;
+const TAG_MAP: u8 = 0x21;
+const TAG_SET: u8 = 0x22;
+const TAG_ATTRIBUTE: u8 = 0x23;
+const TAG_PUSH: u8 = 0x24;
+const TAG_NULL_STRING: u8 = 0x30;
+const TAG_NULL_ARRAY: u8 = 0x31;
+
+/// A parsed BRESP frame. Same variants as RESP3, binary encoding.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Frame {
+    SimpleString(Bytes),
+    Error(Bytes),
+    Integer(i64),
+    BulkString(Option<Bytes>),
+    Null,
+    Double(f64),
+    Boolean(bool),
+    BigNumber(Bytes),
+    BlobError(Bytes),
+    VerbatimString(Bytes, Bytes),
+    Array(Option<Vec<Frame>>),
+    Set(Vec<Frame>),
+    Map(Vec<(Frame, Frame)>),
+    Attribute(Vec<(Frame, Frame)>),
+    Push(Vec<Frame>),
+}
+
+/// Parse error for BRESP.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParseError {
+    Incomplete,
+    InvalidTag(u8),
+}
+
+/// Parse a single BRESP frame from the input.
+pub fn parse_frame(input: Bytes) -> Result<(Frame, Bytes), ParseError> {
+    let (frame, consumed) = parse_inner(&input, 0)?;
+    Ok((frame, input.slice(consumed..)))
+}
+
+fn parse_inner(input: &Bytes, pos: usize) -> Result<(Frame, usize), ParseError> {
+    let buf = input.as_ref();
+    if pos >= buf.len() {
+        return Err(ParseError::Incomplete);
+    }
+
+    let tag = buf[pos];
+    let after_tag = pos + 1;
+
+    match tag {
+        TAG_INTEGER => {
+            if after_tag + 8 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let v = i64::from_be_bytes(buf[after_tag..after_tag + 8].try_into().unwrap());
+            Ok((Frame::Integer(v), after_tag + 8))
+        }
+        TAG_DOUBLE => {
+            if after_tag + 8 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let v = f64::from_be_bytes(buf[after_tag..after_tag + 8].try_into().unwrap());
+            Ok((Frame::Double(v), after_tag + 8))
+        }
+        TAG_BOOLEAN => {
+            if after_tag >= buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            Ok((Frame::Boolean(buf[after_tag] != 0), after_tag + 1))
+        }
+        TAG_NULL => Ok((Frame::Null, after_tag)),
+        TAG_NULL_STRING => Ok((Frame::BulkString(None), after_tag)),
+        TAG_NULL_ARRAY => Ok((Frame::Array(None), after_tag)),
+
+        TAG_STRING => parse_blob(input, buf, after_tag, |b| Frame::BulkString(Some(b))),
+        TAG_ERROR => parse_blob(input, buf, after_tag, Frame::Error),
+        TAG_BLOB_ERROR => parse_blob(input, buf, after_tag, Frame::BlobError),
+        TAG_BIG_NUMBER => parse_blob(input, buf, after_tag, Frame::BigNumber),
+
+        TAG_VERBATIM => {
+            if after_tag + 3 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let format = input.slice(after_tag..after_tag + 3);
+            let len_pos = after_tag + 3;
+            if len_pos + 4 > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let len = u32::from_be_bytes(buf[len_pos..len_pos + 4].try_into().unwrap()) as usize;
+            let data_start = len_pos + 4;
+            if data_start + len > buf.len() {
+                return Err(ParseError::Incomplete);
+            }
+            let content = input.slice(data_start..data_start + len);
+            Ok((Frame::VerbatimString(format, content), data_start + len))
+        }
+
+        TAG_ARRAY => parse_list(input, buf, after_tag, |items| Frame::Array(Some(items))),
+        TAG_SET => parse_list(input, buf, after_tag, Frame::Set),
+        TAG_PUSH => parse_list(input, buf, after_tag, Frame::Push),
+
+        TAG_MAP => parse_pairs(input, buf, after_tag, Frame::Map),
+        TAG_ATTRIBUTE => parse_pairs(input, buf, after_tag, Frame::Attribute),
+
+        _ => Err(ParseError::InvalidTag(tag)),
+    }
+}
+
+#[inline]
+fn read_u32_len(buf: &[u8], pos: usize) -> Result<(usize, usize), ParseError> {
+    if pos + 4 > buf.len() {
+        return Err(ParseError::Incomplete);
+    }
+    let len = u32::from_be_bytes(buf[pos..pos + 4].try_into().unwrap()) as usize;
+    Ok((len, pos + 4))
+}
+
+fn parse_blob(
+    input: &Bytes,
+    buf: &[u8],
+    pos: usize,
+    make: impl FnOnce(Bytes) -> Frame,
+) -> Result<(Frame, usize), ParseError> {
+    let (len, data_start) = read_u32_len(buf, pos)?;
+    if data_start + len > buf.len() {
+        return Err(ParseError::Incomplete);
+    }
+    let data = if len == 0 {
+        Bytes::new()
+    } else {
+        input.slice(data_start..data_start + len)
+    };
+    Ok((make(data), data_start + len))
+}
+
+fn parse_list(
+    input: &Bytes,
+    buf: &[u8],
+    pos: usize,
+    make: impl FnOnce(Vec<Frame>) -> Frame,
+) -> Result<(Frame, usize), ParseError> {
+    let (count, mut cursor) = read_u32_len(buf, pos)?;
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (frame, next) = parse_inner(input, cursor)?;
+        items.push(frame);
+        cursor = next;
+    }
+    Ok((make(items), cursor))
+}
+
+fn parse_pairs(
+    input: &Bytes,
+    buf: &[u8],
+    pos: usize,
+    make: impl FnOnce(Vec<(Frame, Frame)>) -> Frame,
+) -> Result<(Frame, usize), ParseError> {
+    let (count, mut cursor) = read_u32_len(buf, pos)?;
+    let mut pairs = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (key, next1) = parse_inner(input, cursor)?;
+        let (val, next2) = parse_inner(input, next1)?;
+        pairs.push((key, val));
+        cursor = next2;
+    }
+    Ok((make(pairs), cursor))
+}
+
+/// Serialize a BRESP frame to bytes.
+pub fn frame_to_bytes(frame: &Frame) -> Bytes {
+    let mut buf = BytesMut::new();
+    serialize(frame, &mut buf);
+    buf.freeze()
+}
+
+fn serialize(frame: &Frame, buf: &mut BytesMut) {
+    match frame {
+        Frame::Integer(v) => {
+            buf.put_u8(TAG_INTEGER);
+            buf.put_i64(*v);
+        }
+        Frame::Double(v) => {
+            buf.put_u8(TAG_DOUBLE);
+            buf.put_f64(*v);
+        }
+        Frame::Boolean(v) => {
+            buf.put_u8(TAG_BOOLEAN);
+            buf.put_u8(if *v { 1 } else { 0 });
+        }
+        Frame::Null => buf.put_u8(TAG_NULL),
+        Frame::SimpleString(s) => serialize_blob(TAG_STRING, s, buf),
+        Frame::Error(e) => serialize_blob(TAG_ERROR, e, buf),
+        Frame::BlobError(e) => serialize_blob(TAG_BLOB_ERROR, e, buf),
+        Frame::BigNumber(n) => serialize_blob(TAG_BIG_NUMBER, n, buf),
+        Frame::BulkString(Some(s)) => serialize_blob(TAG_STRING, s, buf),
+        Frame::BulkString(None) => buf.put_u8(TAG_NULL_STRING),
+        Frame::VerbatimString(format, content) => {
+            buf.put_u8(TAG_VERBATIM);
+            buf.put_slice(format);
+            buf.put_u32(content.len() as u32);
+            buf.put_slice(content);
+        }
+        Frame::Array(Some(items)) => serialize_list(TAG_ARRAY, items, buf),
+        Frame::Array(None) => buf.put_u8(TAG_NULL_ARRAY),
+        Frame::Set(items) => serialize_list(TAG_SET, items, buf),
+        Frame::Push(items) => serialize_list(TAG_PUSH, items, buf),
+        Frame::Map(pairs) => serialize_pairs(TAG_MAP, pairs, buf),
+        Frame::Attribute(pairs) => serialize_pairs(TAG_ATTRIBUTE, pairs, buf),
+    }
+}
+
+fn serialize_blob(tag: u8, data: &Bytes, buf: &mut BytesMut) {
+    buf.put_u8(tag);
+    buf.put_u32(data.len() as u32);
+    buf.put_slice(data);
+}
+
+fn serialize_list(tag: u8, items: &[Frame], buf: &mut BytesMut) {
+    buf.put_u8(tag);
+    buf.put_u32(items.len() as u32);
+    for item in items {
+        serialize(item, buf);
+    }
+}
+
+fn serialize_pairs(tag: u8, pairs: &[(Frame, Frame)], buf: &mut BytesMut) {
+    buf.put_u8(tag);
+    buf.put_u32(pairs.len() as u32);
+    for (key, val) in pairs {
+        serialize(key, buf);
+        serialize(val, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_integer() {
+        let frame = Frame::Integer(i64::MAX);
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 9); // tag + 8 bytes
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_double() {
+        let frame = Frame::Double(1.23456789);
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 9);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_boolean() {
+        for v in [true, false] {
+            let frame = Frame::Boolean(v);
+            let wire = frame_to_bytes(&frame);
+            assert_eq!(wire.len(), 2);
+            let (parsed, _) = parse_frame(wire).unwrap();
+            assert_eq!(parsed, frame);
+        }
+    }
+
+    #[test]
+    fn roundtrip_null() {
+        let wire = frame_to_bytes(&Frame::Null);
+        assert_eq!(wire.len(), 1);
+        let (parsed, _) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, Frame::Null);
+    }
+
+    #[test]
+    fn roundtrip_string() {
+        // SimpleString and BulkString(Some) both serialize as TAG_STRING
+        // and parse back as BulkString(Some) -- no distinction in binary format
+        let frame = Frame::SimpleString(Bytes::from("OK"));
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 1 + 4 + 2); // tag + len + "OK"
+        let (parsed, _) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, Frame::BulkString(Some(Bytes::from("OK"))));
+    }
+
+    #[test]
+    fn roundtrip_bulk_null() {
+        let frame = Frame::BulkString(None);
+        let wire = frame_to_bytes(&frame);
+        assert_eq!(wire.len(), 1);
+        let (parsed, _) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+    }
+
+    #[test]
+    fn roundtrip_array() {
+        let frame = Frame::Array(Some(vec![
+            Frame::BulkString(Some(Bytes::from("SET"))),
+            Frame::BulkString(Some(Bytes::from("key"))),
+            Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+        let wire = frame_to_bytes(&frame);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_map() {
+        let frame = Frame::Map(vec![
+            (
+                Frame::BulkString(Some(Bytes::from("key1"))),
+                Frame::Integer(1),
+            ),
+            (
+                Frame::BulkString(Some(Bytes::from("key2"))),
+                Frame::Integer(2),
+            ),
+        ]);
+        let wire = frame_to_bytes(&frame);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_verbatim() {
+        let frame = Frame::VerbatimString(Bytes::from("txt"), Bytes::from("hello world"));
+        let wire = frame_to_bytes(&frame);
+        let (parsed, rest) = parse_frame(wire).unwrap();
+        assert_eq!(parsed, frame);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn wire_size_comparison() {
+        // SET key value command
+        let frame = Frame::Array(Some(vec![
+            Frame::BulkString(Some(Bytes::from("SET"))),
+            Frame::BulkString(Some(Bytes::from("key"))),
+            Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+
+        let bresp_wire = frame_to_bytes(&frame);
+
+        // Equivalent RESP3 wire format
+        let resp3_wire = "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n";
+
+        println!("SET key value:");
+        println!("  RESP3: {} bytes", resp3_wire.len());
+        println!("  BRESP: {} bytes", bresp_wire.len());
+        println!(
+            "  Savings: {} bytes ({:.0}%)",
+            resp3_wire.len() as i64 - bresp_wire.len() as i64,
+            (1.0 - bresp_wire.len() as f64 / resp3_wire.len() as f64) * 100.0
+        );
+    }
+}

--- a/experiments/proto-resp/Cargo.toml
+++ b/experiments/proto-resp/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "proto-resp"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "Experimental protobuf-encoded RESP protocol"
+
+[dependencies]
+bytes = "1"
+prost = "0.13"
+resp-rs = { path = "../.." }
+
+[build-dependencies]
+prost-build = "0.13"

--- a/experiments/proto-resp/README.md
+++ b/experiments/proto-resp/README.md
@@ -1,0 +1,75 @@
+# proto-resp -- Protobuf RESP
+
+RESP3 frame types modeled as Protocol Buffers messages.
+
+## Schema
+
+```protobuf
+message Frame {
+  oneof kind {
+    bytes simple_string = 1;
+    bytes error = 2;
+    int64 integer = 3;
+    NullableBytes bulk_string = 4;
+    Null null = 5;
+    double double_val = 6;
+    bool boolean = 7;
+    bytes big_number = 8;
+    bytes blob_error = 9;
+    VerbatimString verbatim_string = 10;
+    NullableArray array = 11;
+    FrameList set = 12;
+    PairList map = 13;
+    PairList attribute = 14;
+    FrameList push = 15;
+  }
+}
+```
+
+See [proto/resp.proto](proto/resp.proto) for the full schema.
+
+## Performance characteristics
+
+**Scalars: 5x faster than RESP3.** Protobuf decodes integers and doubles into
+native types without `Bytes` reference counting. An i64 decodes in 9ns vs 48ns
+for RESP3 text parsing.
+
+**Collections: 2-5x slower than RESP3.** Each nested `Frame` in the generated
+code is a heap-allocated `Box<Frame>`, creating a deep allocation tree. The
+hand-rolled RESP3 parser uses flat `Vec::with_capacity` which is much more
+efficient for Redis's array-heavy command responses.
+
+## Why this is interesting
+
+The performance story is mixed, but performance isn't the main point. The
+protobuf schema is interesting as a foundation for:
+
+**IDL-first client generation.** Define the Redis command set as protobuf
+services and every language gets a correct, typed client from `protoc`. No more
+reimplementing command builders and RESP parsing per language.
+
+**gRPC integration.** Wrap the frame types in gRPC services to get:
+- Typed request/response RPCs for commands
+- Server-side streaming for SCAN, SUBSCRIBE, MONITOR
+- Bidirectional streaming for pub/sub
+- Connection multiplexing, flow control, and TLS from HTTP/2
+
+**Schema evolution.** Adding new frame types is a backwards-compatible proto
+change (new `oneof` fields). Old clients ignore unknown fields gracefully.
+
+## Future direction
+
+The natural next step is defining a `RedisService` proto that maps Redis
+commands to typed RPCs:
+
+```protobuf
+service Redis {
+  rpc Get(GetRequest) returns (GetResponse);
+  rpc Set(SetRequest) returns (SetResponse);
+  rpc Subscribe(SubscribeRequest) returns (stream Frame);
+  rpc Pipeline(stream Frame) returns (stream Frame);
+}
+```
+
+This would make the protocol self-describing and give every language a
+complete, correct client implementation for free.

--- a/experiments/proto-resp/build.rs
+++ b/experiments/proto-resp/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    prost_build::compile_protos(&["proto/resp.proto"], &["proto/"]).unwrap();
+}

--- a/experiments/proto-resp/proto/resp.proto
+++ b/experiments/proto-resp/proto/resp.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package resp;
+
+// A RESP frame modeled as a protobuf message.
+// Covers all RESP2 and RESP3 types.
+message Frame {
+  oneof kind {
+    bytes simple_string = 1;
+    bytes error = 2;
+    int64 integer = 3;
+    NullableBytes bulk_string = 4;
+    Null null = 5;
+    double double_val = 6;
+    bool boolean = 7;
+    bytes big_number = 8;
+    bytes blob_error = 9;
+    VerbatimString verbatim_string = 10;
+    NullableArray array = 11;
+    FrameList set = 12;
+    PairList map = 13;
+    PairList attribute = 14;
+    FrameList push = 15;
+  }
+}
+
+// Null type (RESP3 _\r\n)
+message Null {}
+
+// Bulk string that can be null ($-1)
+message NullableBytes {
+  optional bytes data = 1;
+}
+
+// Array that can be null (*-1)
+message NullableArray {
+  optional FrameList items = 1;
+}
+
+// List of frames (for Array, Set, Push)
+message FrameList {
+  repeated Frame items = 1;
+}
+
+// Key-value pair
+message Pair {
+  Frame key = 1;
+  Frame value = 2;
+}
+
+// List of key-value pairs (for Map, Attribute)
+message PairList {
+  repeated Pair entries = 1;
+}
+
+// Verbatim string with format tag
+message VerbatimString {
+  bytes format = 1;
+  bytes content = 2;
+}

--- a/experiments/proto-resp/src/lib.rs
+++ b/experiments/proto-resp/src/lib.rs
@@ -1,0 +1,194 @@
+//! Protobuf-encoded RESP frames (experimental).
+//!
+//! Models RESP3 frame types as Protocol Buffers messages for comparison
+//! benchmarking. Same semantics as RESP3, protobuf wire encoding.
+
+/// Generated protobuf types.
+pub mod pb {
+    include!(concat!(env!("OUT_DIR"), "/resp.rs"));
+}
+
+use bytes::Bytes;
+
+/// Convert a resp3::Frame to a protobuf Frame.
+pub fn resp3_to_proto(frame: &resp_rs::resp3::Frame) -> pb::Frame {
+    use pb::frame::Kind;
+    use resp_rs::resp3::Frame as R;
+
+    let kind = match frame {
+        R::SimpleString(b) => Kind::SimpleString(b.to_vec()),
+        R::Error(b) => Kind::Error(b.to_vec()),
+        R::Integer(v) => Kind::Integer(*v),
+        R::Double(v) => Kind::DoubleVal(*v),
+        R::Boolean(v) => Kind::Boolean(*v),
+        R::Null => Kind::Null(pb::Null {}),
+        R::BulkString(Some(b)) => Kind::BulkString(pb::NullableBytes {
+            data: Some(b.to_vec()),
+        }),
+        R::BulkString(None) => Kind::BulkString(pb::NullableBytes { data: None }),
+        R::BlobError(b) => Kind::BlobError(b.to_vec()),
+        R::BigNumber(b) => Kind::BigNumber(b.to_vec()),
+        R::VerbatimString(fmt, content) => Kind::VerbatimString(pb::VerbatimString {
+            format: fmt.to_vec(),
+            content: content.to_vec(),
+        }),
+        R::Array(Some(items)) => Kind::Array(pb::NullableArray {
+            items: Some(pb::FrameList {
+                items: items.iter().map(resp3_to_proto).collect(),
+            }),
+        }),
+        R::Array(None) => Kind::Array(pb::NullableArray { items: None }),
+        R::Set(items) => Kind::Set(pb::FrameList {
+            items: items.iter().map(resp3_to_proto).collect(),
+        }),
+        R::Map(pairs) => Kind::Map(pb::PairList {
+            entries: pairs
+                .iter()
+                .map(|(k, v)| pb::Pair {
+                    key: Some(resp3_to_proto(k)),
+                    value: Some(resp3_to_proto(v)),
+                })
+                .collect(),
+        }),
+        R::Attribute(pairs) => Kind::Attribute(pb::PairList {
+            entries: pairs
+                .iter()
+                .map(|(k, v)| pb::Pair {
+                    key: Some(resp3_to_proto(k)),
+                    value: Some(resp3_to_proto(v)),
+                })
+                .collect(),
+        }),
+        R::Push(items) => Kind::Push(pb::FrameList {
+            items: items.iter().map(resp3_to_proto).collect(),
+        }),
+        // Streaming types don't have a protobuf equivalent
+        _ => Kind::Null(pb::Null {}),
+    };
+
+    pb::Frame { kind: Some(kind) }
+}
+
+/// Convert a protobuf Frame back to a resp3::Frame.
+pub fn proto_to_resp3(frame: &pb::Frame) -> resp_rs::resp3::Frame {
+    use pb::frame::Kind;
+    use resp_rs::resp3::Frame as R;
+
+    match frame.kind.as_ref().unwrap() {
+        Kind::SimpleString(b) => R::SimpleString(Bytes::from(b.clone())),
+        Kind::Error(b) => R::Error(Bytes::from(b.clone())),
+        Kind::Integer(v) => R::Integer(*v),
+        Kind::DoubleVal(v) => R::Double(*v),
+        Kind::Boolean(v) => R::Boolean(*v),
+        Kind::Null(_) => R::Null,
+        Kind::BulkString(nb) => R::BulkString(nb.data.as_ref().map(|b| Bytes::from(b.clone()))),
+        Kind::BlobError(b) => R::BlobError(Bytes::from(b.clone())),
+        Kind::BigNumber(b) => R::BigNumber(Bytes::from(b.clone())),
+        Kind::VerbatimString(vs) => R::VerbatimString(
+            Bytes::from(vs.format.clone()),
+            Bytes::from(vs.content.clone()),
+        ),
+        Kind::Array(na) => match &na.items {
+            Some(list) => R::Array(Some(list.items.iter().map(proto_to_resp3).collect())),
+            None => R::Array(None),
+        },
+        Kind::Set(list) => R::Set(list.items.iter().map(proto_to_resp3).collect()),
+        Kind::Map(pairs) => R::Map(
+            pairs
+                .entries
+                .iter()
+                .map(|p| {
+                    (
+                        proto_to_resp3(p.key.as_ref().unwrap()),
+                        proto_to_resp3(p.value.as_ref().unwrap()),
+                    )
+                })
+                .collect(),
+        ),
+        Kind::Attribute(pairs) => R::Attribute(
+            pairs
+                .entries
+                .iter()
+                .map(|p| {
+                    (
+                        proto_to_resp3(p.key.as_ref().unwrap()),
+                        proto_to_resp3(p.value.as_ref().unwrap()),
+                    )
+                })
+                .collect(),
+        ),
+        Kind::Push(list) => R::Push(list.items.iter().map(proto_to_resp3).collect()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn roundtrip_simple_string() {
+        let original = resp_rs::resp3::Frame::SimpleString(Bytes::from("OK"));
+        let proto = resp3_to_proto(&original);
+        let mut buf = Vec::new();
+        proto.encode(&mut buf).unwrap();
+        let decoded_proto = pb::Frame::decode(buf.as_slice()).unwrap();
+        let back = proto_to_resp3(&decoded_proto);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn roundtrip_set_command() {
+        let original = resp_rs::resp3::Frame::Array(Some(vec![
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("SET"))),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("key"))),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+        let proto = resp3_to_proto(&original);
+        let mut buf = Vec::new();
+        proto.encode(&mut buf).unwrap();
+        let decoded_proto = pb::Frame::decode(buf.as_slice()).unwrap();
+        let back = proto_to_resp3(&decoded_proto);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn roundtrip_map() {
+        let original = resp_rs::resp3::Frame::Map(vec![
+            (
+                resp_rs::resp3::Frame::SimpleString(Bytes::from("key1")),
+                resp_rs::resp3::Frame::Integer(42),
+            ),
+            (
+                resp_rs::resp3::Frame::SimpleString(Bytes::from("key2")),
+                resp_rs::resp3::Frame::Boolean(true),
+            ),
+        ]);
+        let proto = resp3_to_proto(&original);
+        let mut buf = Vec::new();
+        proto.encode(&mut buf).unwrap();
+        let decoded_proto = pb::Frame::decode(buf.as_slice()).unwrap();
+        let back = proto_to_resp3(&decoded_proto);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn wire_size_comparison() {
+        use prost::Message;
+
+        // SET key value
+        let frame = resp_rs::resp3::Frame::Array(Some(vec![
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("SET"))),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("key"))),
+            resp_rs::resp3::Frame::BulkString(Some(Bytes::from("value"))),
+        ]));
+
+        let resp3_wire = resp_rs::resp3::frame_to_bytes(&frame);
+        let proto = resp3_to_proto(&frame);
+        let proto_size = proto.encoded_len();
+
+        println!("SET key value wire sizes:");
+        println!("  RESP3:    {} bytes", resp3_wire.len());
+        println!("  Protobuf: {} bytes", proto_size);
+    }
+}

--- a/experiments/throughput/Cargo.toml
+++ b/experiments/throughput/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "throughput"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+bresp = { path = "../bresp" }
+bytes = "1"
+clap = { version = "4", features = ["derive"] }
+prost = "0.13"
+proto-resp = { path = "../proto-resp" }
+resp-rs = { path = "../.." }
+tokio = { version = "1", features = ["full"] }

--- a/experiments/throughput/src/main.rs
+++ b/experiments/throughput/src/main.rs
@@ -132,30 +132,25 @@ async fn read_one_frame(
         if !buf.is_empty() {
             let frozen = buf.clone().freeze();
             let consumed = match format {
-                Format::Resp3 => {
-                    match resp_rs::resp3::parse_frame(frozen) {
-                        Ok((_, rest)) => Some(buf.len() - rest.len()),
-                        Err(resp_rs::ParseError::Incomplete) => None,
-                        Err(_) => return Ok(false),
-                    }
-                }
-                Format::Bresp => {
-                    match bresp::parse_frame(frozen) {
-                        Ok((_, rest)) => Some(buf.len() - rest.len()),
-                        Err(bresp::ParseError::Incomplete) => None,
-                        Err(_) => return Ok(false),
-                    }
-                }
+                Format::Resp3 => match resp_rs::resp3::parse_frame(frozen) {
+                    Ok((_, rest)) => Some(buf.len() - rest.len()),
+                    Err(resp_rs::ParseError::Incomplete) => None,
+                    Err(_) => return Ok(false),
+                },
+                Format::Bresp => match bresp::parse_frame(frozen) {
+                    Ok((_, rest)) => Some(buf.len() - rest.len()),
+                    Err(bresp::ParseError::Incomplete) => None,
+                    Err(_) => return Ok(false),
+                },
                 Format::Proto => {
                     // Length-prefixed: 4-byte u32 + message
                     if buf.len() < 4 {
                         None
                     } else {
-                        let len =
-                            u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
+                        let len = u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
                         if buf.len() >= 4 + len {
-                            let _ = proto_resp::pb::Frame::decode(&buf[4..4 + len])
-                                .map_err(|e| {
+                            let _ =
+                                proto_resp::pb::Frame::decode(&buf[4..4 + len]).map_err(|e| {
                                     std::io::Error::new(std::io::ErrorKind::InvalidData, e)
                                 })?;
                             Some(4 + len)
@@ -240,7 +235,11 @@ async fn run_client(addr: &str, format: Format, num: usize) -> std::io::Result<(
     println!("  Total time:    {elapsed:.2?}");
     println!("  Throughput:    {rps:.0} req/s");
     println!("  Latency:       {us_per_req:.1} us/req");
-    println!("  Wire size:     {} bytes/req, {} bytes/resp", request.len(), encode_response(format).len());
+    println!(
+        "  Wire size:     {} bytes/req, {} bytes/resp",
+        request.len(),
+        encode_response(format).len()
+    );
 
     Ok(())
 }

--- a/experiments/throughput/src/main.rs
+++ b/experiments/throughput/src/main.rs
@@ -1,0 +1,296 @@
+//! End-to-end throughput test: RESP3 vs BRESP vs Protobuf over TCP.
+//!
+//! Sends N requests through a real socket to measure whether protocol
+//! encoding differences matter in practice (spoiler: probably not).
+//!
+//! Usage:
+//!   cargo run -p throughput --release -- --help
+//!   cargo run -p throughput --release -- server --format resp3
+//!   cargo run -p throughput --release -- client --format resp3 -n 100000
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use clap::{Parser, Subcommand, ValueEnum};
+use prost::Message;
+use std::time::Instant;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+#[derive(Clone, Copy, ValueEnum, Debug)]
+enum Format {
+    Resp3,
+    Bresp,
+    Proto,
+}
+
+#[derive(Parser)]
+#[command(name = "throughput", about = "RESP encoding throughput test over TCP")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run the echo server
+    Server {
+        #[arg(short, long, default_value = "127.0.0.1:9999")]
+        addr: String,
+        #[arg(short, long, value_enum, default_value = "resp3")]
+        format: Format,
+    },
+    /// Run the client benchmark
+    Client {
+        #[arg(short, long, default_value = "127.0.0.1:9999")]
+        addr: String,
+        #[arg(short, long, value_enum, default_value = "resp3")]
+        format: Format,
+        /// Number of requests to send
+        #[arg(short, long, default_value = "100000")]
+        num: usize,
+    },
+    /// Run server + client together (easiest way to test)
+    Both {
+        #[arg(short, long, value_enum, default_value = "resp3")]
+        format: Format,
+        #[arg(short, long, default_value = "100000")]
+        num: usize,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Encoding helpers: each format needs encode_request, encode_response,
+// and a way to read one frame from a stream.
+// ---------------------------------------------------------------------------
+
+/// Encode a SET key value command in the given format.
+fn encode_request(format: Format, key: &[u8], value: &[u8]) -> Vec<u8> {
+    match format {
+        Format::Resp3 => {
+            let frame = resp_rs::resp3::Frame::Array(Some(vec![
+                resp_rs::resp3::Frame::BulkString(Some(Bytes::from_static(b"SET"))),
+                resp_rs::resp3::Frame::BulkString(Some(Bytes::copy_from_slice(key))),
+                resp_rs::resp3::Frame::BulkString(Some(Bytes::copy_from_slice(value))),
+            ]));
+            resp_rs::resp3::frame_to_bytes(&frame).to_vec()
+        }
+        Format::Bresp => {
+            let frame = bresp::Frame::Array(Some(vec![
+                bresp::Frame::BulkString(Some(Bytes::from_static(b"SET"))),
+                bresp::Frame::BulkString(Some(Bytes::copy_from_slice(key))),
+                bresp::Frame::BulkString(Some(Bytes::copy_from_slice(value))),
+            ]));
+            bresp::frame_to_bytes(&frame).to_vec()
+        }
+        Format::Proto => {
+            let frame = proto_resp::resp3_to_proto(&resp_rs::resp3::Frame::Array(Some(vec![
+                resp_rs::resp3::Frame::BulkString(Some(Bytes::from_static(b"SET"))),
+                resp_rs::resp3::Frame::BulkString(Some(Bytes::copy_from_slice(key))),
+                resp_rs::resp3::Frame::BulkString(Some(Bytes::copy_from_slice(value))),
+            ])));
+            // Length-prefix the protobuf message so we know where it ends
+            let encoded = frame.encode_to_vec();
+            let mut buf = Vec::with_capacity(4 + encoded.len());
+            buf.put_u32(encoded.len() as u32);
+            buf.extend_from_slice(&encoded);
+            buf
+        }
+    }
+}
+
+/// Encode a +OK response in the given format.
+fn encode_response(format: Format) -> Vec<u8> {
+    match format {
+        Format::Resp3 => {
+            let frame = resp_rs::resp3::Frame::SimpleString(Bytes::from_static(b"OK"));
+            resp_rs::resp3::frame_to_bytes(&frame).to_vec()
+        }
+        Format::Bresp => {
+            let frame = bresp::Frame::SimpleString(Bytes::from_static(b"OK"));
+            bresp::frame_to_bytes(&frame).to_vec()
+        }
+        Format::Proto => {
+            let frame = proto_resp::resp3_to_proto(&resp_rs::resp3::Frame::SimpleString(
+                Bytes::from_static(b"OK"),
+            ));
+            let encoded = frame.encode_to_vec();
+            let mut buf = Vec::with_capacity(4 + encoded.len());
+            buf.put_u32(encoded.len() as u32);
+            buf.extend_from_slice(&encoded);
+            buf
+        }
+    }
+}
+
+/// Read one frame from a TCP stream. Returns number of bytes consumed.
+async fn read_one_frame(
+    stream: &mut TcpStream,
+    buf: &mut BytesMut,
+    format: Format,
+) -> std::io::Result<bool> {
+    loop {
+        // Try to parse from what we have
+        if !buf.is_empty() {
+            let frozen = buf.clone().freeze();
+            let consumed = match format {
+                Format::Resp3 => {
+                    match resp_rs::resp3::parse_frame(frozen) {
+                        Ok((_, rest)) => Some(buf.len() - rest.len()),
+                        Err(resp_rs::ParseError::Incomplete) => None,
+                        Err(_) => return Ok(false),
+                    }
+                }
+                Format::Bresp => {
+                    match bresp::parse_frame(frozen) {
+                        Ok((_, rest)) => Some(buf.len() - rest.len()),
+                        Err(bresp::ParseError::Incomplete) => None,
+                        Err(_) => return Ok(false),
+                    }
+                }
+                Format::Proto => {
+                    // Length-prefixed: 4-byte u32 + message
+                    if buf.len() < 4 {
+                        None
+                    } else {
+                        let len =
+                            u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
+                        if buf.len() >= 4 + len {
+                            let _ = proto_resp::pb::Frame::decode(&buf[4..4 + len])
+                                .map_err(|e| {
+                                    std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+                                })?;
+                            Some(4 + len)
+                        } else {
+                            None
+                        }
+                    }
+                }
+            };
+
+            if let Some(n) = consumed {
+                buf.advance(n);
+                return Ok(true);
+            }
+        }
+
+        // Need more data
+        let n = stream.read_buf(buf).await?;
+        if n == 0 {
+            return Ok(false);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+async fn run_server(addr: &str, format: Format) -> std::io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    eprintln!("[server] listening on {addr} ({format:?})");
+
+    let response = encode_response(format);
+
+    loop {
+        let (mut stream, peer) = listener.accept().await?;
+        eprintln!("[server] connection from {peer}");
+        let response = response.clone();
+
+        tokio::spawn(async move {
+            let mut buf = BytesMut::with_capacity(4096);
+            loop {
+                match read_one_frame(&mut stream, &mut buf, format).await {
+                    Ok(true) => {
+                        if stream.write_all(&response).await.is_err() {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+async fn run_client(addr: &str, format: Format, num: usize) -> std::io::Result<()> {
+    let mut stream = TcpStream::connect(addr).await?;
+    stream.set_nodelay(true)?;
+    eprintln!("[client] connected to {addr} ({format:?}), sending {num} requests");
+
+    let request = encode_request(format, b"key", b"value");
+    let mut buf = BytesMut::with_capacity(4096);
+
+    let start = Instant::now();
+
+    for _ in 0..num {
+        stream.write_all(&request).await?;
+        read_one_frame(&mut stream, &mut buf, format).await?;
+    }
+
+    let elapsed = start.elapsed();
+    let rps = num as f64 / elapsed.as_secs_f64();
+    let us_per_req = elapsed.as_micros() as f64 / num as f64;
+
+    println!();
+    println!("=== {format:?} Results ===");
+    println!("  Requests:      {num}");
+    println!("  Total time:    {elapsed:.2?}");
+    println!("  Throughput:    {rps:.0} req/s");
+    println!("  Latency:       {us_per_req:.1} us/req");
+    println!("  Wire size:     {} bytes/req, {} bytes/resp", request.len(), encode_response(format).len());
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Server { addr, format } => run_server(&addr, format).await,
+        Command::Client { addr, format, num } => run_client(&addr, format, num).await,
+        Command::Both { format, num } => {
+            let addr = "127.0.0.1:0";
+            let listener = TcpListener::bind(addr).await?;
+            let bound_addr = listener.local_addr()?;
+            let addr_str = bound_addr.to_string();
+            eprintln!("[both] server on {addr_str} ({format:?})");
+
+            let response = encode_response(format);
+
+            // Spawn server
+            tokio::spawn(async move {
+                loop {
+                    if let Ok((mut stream, _)) = listener.accept().await {
+                        let response = response.clone();
+                        tokio::spawn(async move {
+                            let mut buf = BytesMut::with_capacity(4096);
+                            loop {
+                                match read_one_frame(&mut stream, &mut buf, format).await {
+                                    Ok(true) => {
+                                        if stream.write_all(&response).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                    _ => break,
+                                }
+                            }
+                        });
+                    }
+                }
+            });
+
+            // Small delay for server to start
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+            run_client(&addr_str, format, num).await
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Move the BRESP and protobuf-RESP experiments into separate workspace crates, keeping the published resp-rs crate clean.

**Structure:**
- \`experiments/bresp/\` -- binary RESP protocol (own crate, own tests)
- \`experiments/proto-resp/\` -- protobuf RESP modeling (own crate, prost dependency isolated here)
- \`experiments/bench/\` -- three-way comparison benchmarks
- \`experiments/README.md\` -- overview with benchmark results, analysis, and future directions

Each experiment has a detailed README covering wire format, tradeoffs, and implications. The overall README includes the full benchmark comparison table and the key finding that wire encoding is not the bottleneck for string-heavy workloads.

**Core crate impact: none.** Same 248 tests, same API, same dependencies. The workspace members are \`publish = false\`.

Run benchmarks: \`cargo bench --package experiments-bench --bench three_way\`

## Test plan

- [x] \`cargo test --workspace\` passes (all experiments + core)
- [x] \`cargo test -p resp-rs --all-features\` unchanged (248 tests)
- [x] Three-way benchmark runs correctly
- [x] clippy clean across workspace