### PR TITLE
fix: accept explicit plus sign on integers and classify trailing junk correctly

### DIFF
--- a/src/resp2.rs
+++ b/src/resp2.rs
@@ -481,25 +481,33 @@ fn parse_count(buf: &[u8]) -> Result<usize, ParseError> {
     Ok(count)
 }
 
-/// Parse an `i64` directly from ASCII bytes (optional leading `-`), no UTF-8 validation.
+/// Parse an `i64` directly from ASCII bytes, no UTF-8 validation.
+///
+/// The sign is optional and may be `+` or `-`, matching the grammar
+/// `:[<+|->]<value>\r\n`. Redis does not emit the `+` form, but the spec
+/// allows it and other peers do.
 #[inline]
 fn parse_i64(buf: &[u8]) -> Result<i64, ParseError> {
     if buf.is_empty() {
         return Err(ParseError::InvalidFormat);
     }
-    let (neg, digits) = if buf[0] == b'-' {
-        (true, &buf[1..])
-    } else {
-        (false, buf)
+    let (neg, digits) = match buf[0] {
+        b'-' => (true, &buf[1..]),
+        b'+' => (false, &buf[1..]),
+        _ => (false, buf),
     };
     if digits.is_empty() {
         return Err(ParseError::InvalidFormat);
     }
+    // Validate the whole run before accumulating. Deciding this per iteration
+    // lets an earlier byte return Overflow on input that is merely malformed:
+    // the i64::MIN case below is guarded on the digit being last, and trailing
+    // junk inflates the length so that guard misses.
+    if !digits.iter().all(u8::is_ascii_digit) {
+        return Err(ParseError::InvalidFormat);
+    }
     let mut v: i64 = 0;
     for (i, &d) in digits.iter().enumerate() {
-        if !d.is_ascii_digit() {
-            return Err(ParseError::InvalidFormat);
-        }
         let digit = (d - b'0') as i64;
         if neg && v == i64::MAX / 10 && digit == 8 && i == digits.len() - 1 {
             return Ok(i64::MIN);

--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -1056,25 +1056,33 @@ fn parse_usize(buf: &[u8]) -> Result<usize, ParseError> {
     Ok(v)
 }
 
-/// Parse an `i64` directly from ASCII bytes (optional leading `-`), no UTF-8 validation.
+/// Parse an `i64` directly from ASCII bytes, no UTF-8 validation.
+///
+/// The sign is optional and may be `+` or `-`, matching the grammar
+/// `:[<+|->]<value>\r\n`. Redis does not emit the `+` form, but the spec
+/// allows it and other peers do.
 #[inline]
 fn parse_i64(buf: &[u8]) -> Result<i64, ParseError> {
     if buf.is_empty() {
         return Err(ParseError::InvalidFormat);
     }
-    let (neg, digits) = if buf[0] == b'-' {
-        (true, &buf[1..])
-    } else {
-        (false, buf)
+    let (neg, digits) = match buf[0] {
+        b'-' => (true, &buf[1..]),
+        b'+' => (false, &buf[1..]),
+        _ => (false, buf),
     };
     if digits.is_empty() {
         return Err(ParseError::InvalidFormat);
     }
+    // Validate the whole run before accumulating. Deciding this per iteration
+    // lets an earlier byte return Overflow on input that is merely malformed:
+    // the i64::MIN case below is guarded on the digit being last, and trailing
+    // junk inflates the length so that guard misses.
+    if !digits.iter().all(u8::is_ascii_digit) {
+        return Err(ParseError::InvalidFormat);
+    }
     let mut v: i64 = 0;
     for (i, &d) in digits.iter().enumerate() {
-        if !d.is_ascii_digit() {
-            return Err(ParseError::InvalidFormat);
-        }
         let digit = (d - b'0') as i64;
         if neg && v == i64::MAX / 10 && digit == 8 && i == digits.len() - 1 {
             return Ok(i64::MIN);

--- a/tests/resp2.rs
+++ b/tests/resp2.rs
@@ -341,3 +341,128 @@ fn parser_rejects_deep_nesting() {
     parser.feed(nested_arrays(100_000));
     assert_eq!(parser.next_frame(), Err(ParseError::DepthExceeded));
 }
+
+// --- Integer sign and classification (issues #49, #55) ---
+//
+// These cases are transcribed from the RESP grammar `:[<+|->]<value>\r\n`,
+// not from frame_to_bytes. The serializer emits i64 via Display, which never
+// produces a leading `+`, so no test whose input comes from the serializer can
+// reach the signed form. That closed loop is why #49 went unnoticed.
+
+#[test]
+fn integer_accepts_explicit_plus() {
+    for (wire, want) in [
+        (&b":+42\r\n"[..], 42i64),
+        (&b":+0\r\n"[..], 0),
+        (&b":+1\r\n"[..], 1),
+        (&b":+9223372036854775807\r\n"[..], i64::MAX),
+    ] {
+        let (frame, rest) = resp2::parse_frame(Bytes::copy_from_slice(wire))
+            .unwrap_or_else(|e| panic!("{:?}: {e:?}", String::from_utf8_lossy(wire)));
+        assert!(rest.is_empty());
+        assert_eq!(
+            frame,
+            Frame::Integer(want),
+            "{}",
+            String::from_utf8_lossy(wire)
+        );
+    }
+}
+
+#[test]
+fn integer_sign_forms_agree() {
+    // The three spellings of the same value must parse identically.
+    let plus = resp2::parse_frame(Bytes::from_static(b":+42\r\n"))
+        .unwrap()
+        .0;
+    let bare = resp2::parse_frame(Bytes::from_static(b":42\r\n"))
+        .unwrap()
+        .0;
+    assert_eq!(plus, bare);
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b":-42\r\n"))
+            .unwrap()
+            .0,
+        Frame::Integer(-42)
+    );
+}
+
+#[test]
+fn integer_rejects_malformed_signs() {
+    for wire in [
+        &b":+\r\n"[..],
+        &b":-\r\n"[..],
+        &b":++1\r\n"[..],
+        &b":+-1\r\n"[..],
+        &b":-+1\r\n"[..],
+        &b":1+\r\n"[..],
+        &b":+ 1\r\n"[..],
+    ] {
+        assert_eq!(
+            resp2::parse_frame(Bytes::copy_from_slice(wire)),
+            Err(ParseError::InvalidFormat),
+            "{}",
+            String::from_utf8_lossy(wire)
+        );
+    }
+}
+
+#[test]
+fn integer_signed_overflow_matches_unsigned() {
+    // Accepting the sign moves this from InvalidFormat to Overflow, which is
+    // the point: it should classify the same as the unsigned spelling.
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b":+9223372036854775808\r\n")),
+        Err(ParseError::Overflow)
+    );
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b":9223372036854775808\r\n")),
+        Err(ParseError::Overflow)
+    );
+}
+
+#[test]
+fn trailing_junk_is_malformed_not_overflow() {
+    // The i64::MIN digits followed by junk are malformed, not out of range.
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b":-9223372036854775808X\r\n")),
+        Err(ParseError::InvalidFormat)
+    );
+    // Same shape one digit lower, which never tripped the guard.
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b":9223372036854775807X\r\n")),
+        Err(ParseError::InvalidFormat)
+    );
+    // i64::MIN itself must still parse, and one past it is still Overflow.
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b":-9223372036854775808\r\n"))
+            .unwrap()
+            .0,
+        Frame::Integer(i64::MIN)
+    );
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b":-9223372036854775809\r\n")),
+        Err(ParseError::Overflow)
+    );
+}
+
+#[test]
+fn signed_integer_inside_an_aggregate() {
+    // The failure previously took the enclosing frame with it.
+    let (frame, _) = resp2::parse_frame(Bytes::from_static(b"*1\r\n:+42\r\n")).unwrap();
+    assert_eq!(frame, Frame::Array(Some(vec![Frame::Integer(42)])));
+}
+
+#[test]
+fn lengths_and_counts_still_reject_a_plus() {
+    // The sign is part of the integer grammar only. Lengths and counts have no
+    // sign, so a leading `+` must stay rejected there.
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b"$+5\r\nhello\r\n")),
+        Err(ParseError::BadLength)
+    );
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b"*+1\r\n:1\r\n")),
+        Err(ParseError::BadLength)
+    );
+}

--- a/tests/resp3.rs
+++ b/tests/resp3.rs
@@ -528,3 +528,106 @@ fn parser_rejects_deep_nesting() {
     parser.feed(nested("*1\r\n", 100_000));
     assert_eq!(parser.next_frame(), Err(ParseError::DepthExceeded));
 }
+
+// --- Integer sign and classification (issues #49, #55) ---
+//
+// Transcribed from the RESP grammar `:[<+|->]<value>\r\n`, not from
+// frame_to_bytes, which emits i64 via Display and so never produces a leading
+// `+`. Any test whose input comes from the serializer is blind to this form.
+
+#[test]
+fn integer_accepts_explicit_plus() {
+    for (wire, want) in [
+        (&b":+42\r\n"[..], 42i64),
+        (&b":+0\r\n"[..], 0),
+        (&b":+9223372036854775807\r\n"[..], i64::MAX),
+    ] {
+        let (frame, rest) = resp3::parse_frame(Bytes::copy_from_slice(wire))
+            .unwrap_or_else(|e| panic!("{:?}: {e:?}", String::from_utf8_lossy(wire)));
+        assert!(rest.is_empty());
+        assert_eq!(
+            frame,
+            Frame::Integer(want),
+            "{}",
+            String::from_utf8_lossy(wire)
+        );
+    }
+}
+
+#[test]
+fn integer_rejects_malformed_signs() {
+    for wire in [
+        &b":+\r\n"[..],
+        &b":-\r\n"[..],
+        &b":++1\r\n"[..],
+        &b":+-1\r\n"[..],
+        &b":1+\r\n"[..],
+    ] {
+        assert_eq!(
+            resp3::parse_frame(Bytes::copy_from_slice(wire)),
+            Err(ParseError::InvalidFormat),
+            "{}",
+            String::from_utf8_lossy(wire)
+        );
+    }
+}
+
+#[test]
+fn integer_signed_overflow_matches_unsigned() {
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b":+9223372036854775808\r\n")),
+        Err(ParseError::Overflow)
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b":9223372036854775808\r\n")),
+        Err(ParseError::Overflow)
+    );
+}
+
+#[test]
+fn trailing_junk_is_malformed_not_overflow() {
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b":-9223372036854775808X\r\n")),
+        Err(ParseError::InvalidFormat)
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b":-9223372036854775808\r\n"))
+            .unwrap()
+            .0,
+        Frame::Integer(i64::MIN)
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b":-9223372036854775809\r\n")),
+        Err(ParseError::Overflow)
+    );
+}
+
+#[test]
+fn signed_integer_inside_every_aggregate() {
+    // The failure previously took the enclosing frame with it, for all five
+    // recursing tags.
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b"*1\r\n:+42\r\n"))
+            .unwrap()
+            .0,
+        Frame::Array(Some(vec![Frame::Integer(42)]))
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b"~1\r\n:+42\r\n"))
+            .unwrap()
+            .0,
+        Frame::Set(vec![Frame::Integer(42)])
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b">1\r\n:+42\r\n"))
+            .unwrap()
+            .0,
+        Frame::Push(vec![Frame::Integer(42)])
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b"%1\r\n:+1\r\n:+2\r\n"))
+            .unwrap()
+            .0,
+        Frame::Map(vec![(Frame::Integer(1), Frame::Integer(2))])
+    );
+}


### PR DESCRIPTION
Closes #49
Closes #55

Both defects are in `parse_i64`, which is duplicated in `resp2.rs` and `resp3.rs`, so they are fixed together.

## #49: explicit plus sign is rejected

The RESP grammar is `:[<+|->]<value>\r\n`, with an optional plus or minus. `parse_i64` strips only `-`, so `:+42\r\n` fails on the sign byte.

## #55: trailing junk after i64::MIN reports Overflow

The `i64::MIN` special case is guarded on `i == digits.len() - 1`, and `digits` is the whole slice between tag and CRLF, so trailing junk inflates the length. For `-9223372036854775808X` the final `8` sits at index 19 while `digits.len() - 1` is 20, the special case does not fire, and the overflow check on that same iteration returns `Overflow` before the loop ever reaches `X`.

## Plan

Validate the digit run up front, then strip either sign:

```rust
let (neg, digits) = match buf[0] {
    b'-' => (true, &buf[1..]),
    b'+' => (false, &buf[1..]),
    _ => (false, buf),
};
if digits.is_empty() {
    return Err(ParseError::InvalidFormat);
}
if !digits.iter().all(u8::is_ascii_digit) {
    return Err(ParseError::InvalidFormat);
}
```

Validating up front fixes #55 by construction: once every byte is known to be a digit, `digits.len() - 1` means what the `i64::MIN` guard assumes, and the per-iteration non-digit check becomes redundant.

Expected table after the change:

| Input | Before | After |
| --- | --- | --- |
| `:+42\r\n` | `InvalidFormat` | `Ok(Integer(42))` |
| `:-42\r\n` | `Ok(Integer(-42))` | unchanged |
| `:+0\r\n` | `InvalidFormat` | `Ok(Integer(0))` |
| `:+\r\n` | `InvalidFormat` | unchanged |
| `:++1\r\n` | `InvalidFormat` | unchanged |
| `:+9223372036854775808\r\n` | `InvalidFormat` | `Overflow` |
| `:-9223372036854775808X\r\n` | `Overflow` | `InvalidFormat` |
| `:-9223372036854775808\r\n` | `Ok(Integer(i64::MIN))` | unchanged |
| `:-9223372036854775809\r\n` | `Overflow` | unchanged |

Note the `:+9223372036854775808\r\n` row: accepting the sign moves it from `InvalidFormat` to `Overflow`, matching the unsigned form. That is the intended consequence, called out in #49.

## Scope

`parse_i64` only. `parse_usize` and `parse_count` govern lengths and counts, where the grammar has no sign and a leading `+` should stay rejected. `parse_double_frame` has its own sign handling and is out of scope here.

## Tests

Grammar-derived cases for both protocols, covering the table above, plus the enclosing-frame cases from #49 (`*1\r\n:+42\r\n`, `%1\r\n:+1\r\n:+2\r\n`) since the failure previously took the whole frame with it. Serializer output is unchanged, so roundtrip properties are unaffected.