### PR TITLE
fix: RESP3 attributes must not consume an aggregate element slot

### DIFF
--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -625,7 +625,7 @@ fn parse_collection(
     let mut cursor = after_crlf;
     let mut items = Vec::with_capacity(bounded_capacity(buf, after_crlf, count, 1));
     for _ in 0..count {
-        let (item, next) = parse_frame_inner(input, cursor, child_depth)?;
+        let (item, next) = parse_element(input, cursor, child_depth)?;
         items.push(item);
         cursor = next;
     }
@@ -634,6 +634,35 @@ fn parse_collection(
         b'~' => Ok((Frame::Set(items), cursor)),
         b'>' => Ok((Frame::Push(items), cursor)),
         _ => unreachable!(),
+    }
+}
+
+/// Read one aggregate element, skipping any attributes that precede it.
+///
+/// An attribute is not a reply. It carries out-of-band metadata for the frame
+/// that follows, so it does not occupy an element slot: a `*3` header followed
+/// by an attribute is followed by four frames, not three.
+///
+/// Counting the attribute as an element does not merely produce a wrong tree.
+/// The aggregate finishes one element early and the real element is left in the
+/// buffer, where it is returned as the reply to the next command, silently
+/// shifting every reply after it.
+///
+/// The metadata is discarded. Attaching it instead, as redis-protocol does,
+/// would need a field on every [`Frame`] variant, which breaks the API and
+/// grows the type. Dropping it keeps this to the desynchronization.
+///
+/// A bare attribute parsed on its own is unaffected and still yields
+/// [`Frame::Attribute`]; only the in-aggregate position is handled here.
+#[inline]
+fn parse_element(input: &Bytes, pos: usize, depth: u32) -> Result<(Frame, usize), ParseError> {
+    let mut cursor = pos;
+    loop {
+        let (frame, next) = parse_frame_inner(input, cursor, depth)?;
+        cursor = next;
+        if !matches!(frame, Frame::Attribute(_)) {
+            return Ok((frame, cursor));
+        }
     }
 }
 
@@ -662,8 +691,8 @@ fn parse_pairs(
     if count > 0 {
         let child_depth = depth.checked_sub(1).ok_or(ParseError::DepthExceeded)?;
         for _ in 0..count {
-            let (key, next1) = parse_frame_inner(input, cursor, child_depth)?;
-            let (val, next2) = parse_frame_inner(input, next1, child_depth)?;
+            let (key, next1) = parse_element(input, cursor, child_depth)?;
+            let (val, next2) = parse_element(input, next1, child_depth)?;
             pairs.push((key, val));
             cursor = next2;
         }
@@ -2281,13 +2310,39 @@ mod tests {
 
     #[test]
     fn test_roundtrip_nested_structures() {
-        // Test a complex nested structure
+        // Test a complex nested structure.
+        //
+        // The trailing `|1\r\n+meta\r\n+data\r\n` is an attribute, which does
+        // not occupy an element slot, so a real third element follows it. This
+        // input previously ended at the attribute and parsed only because the
+        // attribute was miscounted as that third element (issue #59).
         let original = Bytes::from(
-            "*3\r\n+hello\r\n%2\r\n+key1\r\n:123\r\n+key2\r\n~1\r\n+item\r\n|1\r\n+meta\r\n+data\r\n",
+            "*3\r\n+hello\r\n%2\r\n+key1\r\n:123\r\n+key2\r\n~1\r\n+item\r\n|1\r\n+meta\r\n+data\r\n:42\r\n",
         );
-        let (frame, _) = parse_frame(original.clone()).unwrap();
-        let serialized = frame_to_bytes(&frame);
+        let (frame, rest) = parse_frame(original.clone()).unwrap();
+        assert!(rest.is_empty());
 
+        // The attribute is metadata and is dropped, so the array holds the
+        // three real elements.
+        assert_eq!(
+            frame,
+            Frame::Array(Some(vec![
+                Frame::SimpleString(Bytes::from("hello")),
+                Frame::Map(vec![
+                    (
+                        Frame::SimpleString(Bytes::from("key1")),
+                        Frame::Integer(123)
+                    ),
+                    (
+                        Frame::SimpleString(Bytes::from("key2")),
+                        Frame::Set(vec![Frame::SimpleString(Bytes::from("item"))])
+                    ),
+                ]),
+                Frame::Integer(42),
+            ]))
+        );
+
+        let serialized = frame_to_bytes(&frame);
         let (reparsed, _) = parse_frame(serialized).unwrap();
         assert_eq!(frame, reparsed);
     }

--- a/src/resp3_unchecked.rs
+++ b/src/resp3_unchecked.rs
@@ -46,6 +46,28 @@ unsafe fn parse_i64_unchecked(buf: &[u8]) -> i64 {
     if neg { -v } else { v }
 }
 
+/// Read one aggregate element, skipping any attributes that precede it.
+///
+/// Mirrors `resp3::parse_element`. An attribute is metadata for the frame that
+/// follows and does not occupy an element slot, so the two parsers must agree
+/// on this or the equivalence property between them breaks.
+///
+/// # Safety
+///
+/// Same contract as [`parse_inner`]: `input` holds valid, complete RESP3 from
+/// `pos`, which guarantees a non-attribute frame eventually follows.
+#[inline(always)]
+unsafe fn parse_element(input: &Bytes, pos: usize) -> (Frame, usize) {
+    let mut cursor = pos;
+    loop {
+        let (frame, next) = parse_inner(input, cursor);
+        cursor = next;
+        if !matches!(frame, Frame::Attribute(_)) {
+            return (frame, cursor);
+        }
+    }
+}
+
 unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
     let buf = input.as_ref();
     let tag = *buf.get_unchecked(pos);
@@ -143,7 +165,7 @@ unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
             let mut cursor = cr + 2;
             let mut items = Vec::with_capacity(count);
             for _ in 0..count {
-                let (frame, next) = parse_inner(input, cursor);
+                let (frame, next) = parse_element(input, cursor);
                 items.push(frame);
                 cursor = next;
             }
@@ -159,7 +181,7 @@ unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
             let mut cursor = cr + 2;
             let mut items = Vec::with_capacity(count);
             for _ in 0..count {
-                let (frame, next) = parse_inner(input, cursor);
+                let (frame, next) = parse_element(input, cursor);
                 items.push(frame);
                 cursor = next;
             }
@@ -179,8 +201,8 @@ unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
             let mut cursor = cr + 2;
             let mut pairs = Vec::with_capacity(count);
             for _ in 0..count {
-                let (key, next1) = parse_inner(input, cursor);
-                let (val, next2) = parse_inner(input, next1);
+                let (key, next1) = parse_element(input, cursor);
+                let (val, next2) = parse_element(input, next1);
                 pairs.push((key, val));
                 cursor = next2;
             }
@@ -200,7 +222,7 @@ unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
             let mut cursor = cr + 2;
             let mut items = Vec::with_capacity(count);
             for _ in 0..count {
-                let (frame, next) = parse_inner(input, cursor);
+                let (frame, next) = parse_element(input, cursor);
                 items.push(frame);
                 cursor = next;
             }

--- a/tests/property.proptest-regressions
+++ b/tests/property.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 8ba43a40b199497bdac8a780f25d25157fdf2b62950548cbaf67b4b1639573ee # shrinks to frames = [Map([(SimpleString(b""), Attribute([]))])], split_points = [0]
+cc ac9ee17e16b1b946a21e71dacbca33de217b07004b0ecb10edb3bf403f85af25 # shrinks to frame = Set([Attribute([])])

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -67,7 +67,14 @@ fn arb_resp3_frame() -> impl Strategy<Value = resp_rs::resp3::Frame> {
             }),
     ];
 
-    leaf.prop_recursive(
+    // Attribute is deliberately absent from the recursive branch. An attribute
+    // carries metadata for the frame that follows and does not occupy an
+    // element slot, so the parser skips it inside an aggregate (issue #59).
+    // A Frame::Attribute sitting in an aggregate's Vec is therefore not a
+    // structure the parser can produce, and serializing one emits wire bytes
+    // that mean something different on the way back. Generating it here would
+    // assert a roundtrip that is not claimed.
+    let nested = leaf.prop_recursive(
         3,  // max depth
         64, // max nodes
         6,  // items per collection
@@ -79,14 +86,18 @@ fn arb_resp3_frame() -> impl Strategy<Value = resp_rs::resp3::Frame> {
                 prop::collection::vec(inner.clone(), 0..6).prop_map(Frame::Set),
                 // Map
                 prop::collection::vec((inner.clone(), inner.clone()), 0..4).prop_map(Frame::Map),
-                // Attribute
-                prop::collection::vec((inner.clone(), inner.clone()), 0..4)
-                    .prop_map(Frame::Attribute),
                 // Push
                 prop::collection::vec(inner, 0..6).prop_map(Frame::Push),
             ]
         },
-    )
+    );
+
+    // Attributes are still covered, in the one position where they round-trip:
+    // standing alone, which is where a real peer sends them.
+    prop_oneof![
+        9 => nested.clone(),
+        1 => prop::collection::vec((nested.clone(), nested), 0..4).prop_map(Frame::Attribute),
+    ]
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/resp3.rs
+++ b/tests/resp3.rs
@@ -431,13 +431,19 @@ fn nested(header: &str, depth: usize) -> Bytes {
     Bytes::from(s)
 }
 
-/// Every RESP3 tag that recurses, with the repeat unit that nests it.
+/// Every RESP3 tag that recurses through a repeatable unit, with that unit.
+///
+/// `|` is absent deliberately. An attribute carries metadata for the frame that
+/// follows and is skipped where a frame is expected (issue #59), so a chain of
+/// attributes never reaches a real frame and is not well-formed input. The
+/// attribute depth path is `parse_pairs`, which is the same function `%`
+/// exercises above; `attribute_wrapping_deep_content_respects_max_depth` covers
+/// the `|` tag specifically.
 const NESTING_TAGS: &[&str] = &[
     "*1\r\n",       // array
     "~1\r\n",       // set
     ">1\r\n",       // push
     "%1\r\n+k\r\n", // map: key then nested value
-    "|1\r\n+k\r\n", // attribute: key then nested value
 ];
 
 #[test]
@@ -629,5 +635,184 @@ fn signed_integer_inside_every_aggregate() {
             .unwrap()
             .0,
         Frame::Map(vec![(Frame::Integer(1), Frame::Integer(2))])
+    );
+}
+
+// --- Attributes must not consume an element slot (issue #59) ---
+//
+// An attribute is not a reply. It carries metadata for the frame that follows,
+// so a `*3` header followed by an attribute is followed by four frames. When an
+// attribute eats a slot the aggregate ends early and the real element is left
+// in the buffer, which shifts every subsequent reply on the connection.
+
+#[test]
+fn spec_attribute_example_parses_as_three_elements() {
+    // Straight from the spec's Attributes section.
+    let wire = Bytes::from_static(b"*3\r\n:1\r\n:2\r\n|1\r\n+ttl\r\n:3600\r\n:3\r\n");
+    let (frame, rest) = resp3::parse_frame(wire).unwrap();
+    assert!(rest.is_empty(), "left {rest:?} unconsumed");
+    assert_eq!(
+        frame,
+        Frame::Array(Some(vec![
+            Frame::Integer(1),
+            Frame::Integer(2),
+            Frame::Integer(3)
+        ]))
+    );
+}
+
+#[test]
+fn attribute_in_any_element_position() {
+    let attr = "|1\r\n+ttl\r\n:3600\r\n";
+    for wire in [
+        format!("*3\r\n{attr}:1\r\n:2\r\n:3\r\n"), // first
+        format!("*3\r\n:1\r\n{attr}:2\r\n:3\r\n"), // middle
+        format!("*3\r\n:1\r\n:2\r\n{attr}:3\r\n"), // last
+    ] {
+        let (frame, rest) = resp3::parse_frame(Bytes::from(wire.clone()))
+            .unwrap_or_else(|e| panic!("{wire:?}: {e:?}"));
+        assert!(rest.is_empty(), "{wire:?} left {rest:?}");
+        assert_eq!(
+            frame,
+            Frame::Array(Some(vec![
+                Frame::Integer(1),
+                Frame::Integer(2),
+                Frame::Integer(3)
+            ])),
+            "{wire:?}"
+        );
+    }
+}
+
+#[test]
+fn consecutive_attributes_before_one_element() {
+    let wire = Bytes::from_static(b"*1\r\n|1\r\n+a\r\n:1\r\n|1\r\n+b\r\n:2\r\n:42\r\n");
+    let (frame, rest) = resp3::parse_frame(wire).unwrap();
+    assert!(rest.is_empty());
+    assert_eq!(frame, Frame::Array(Some(vec![Frame::Integer(42)])));
+}
+
+#[test]
+fn attribute_before_a_map_key_or_value() {
+    let attr = "|1\r\n+ttl\r\n:3600\r\n";
+    for wire in [
+        format!("%1\r\n{attr}+k\r\n+v\r\n"), // before the key
+        format!("%1\r\n+k\r\n{attr}+v\r\n"), // before the value
+    ] {
+        let (frame, rest) = resp3::parse_frame(Bytes::from(wire.clone()))
+            .unwrap_or_else(|e| panic!("{wire:?}: {e:?}"));
+        assert!(rest.is_empty(), "{wire:?} left {rest:?}");
+        assert_eq!(
+            frame,
+            Frame::Map(vec![(
+                Frame::SimpleString(Bytes::from_static(b"k")),
+                Frame::SimpleString(Bytes::from_static(b"v"))
+            )]),
+            "{wire:?}"
+        );
+    }
+}
+
+#[test]
+fn attribute_skipped_in_every_aggregate_type() {
+    let attr = "|1\r\n+ttl\r\n:3600\r\n";
+    for (tag, build) in [
+        ("*", Frame::Array(Some(vec![Frame::Integer(1)]))),
+        ("~", Frame::Set(vec![Frame::Integer(1)])),
+        (">", Frame::Push(vec![Frame::Integer(1)])),
+    ] {
+        let wire = format!("{tag}1\r\n{attr}:1\r\n");
+        let (frame, rest) = resp3::parse_frame(Bytes::from(wire.clone()))
+            .unwrap_or_else(|e| panic!("{wire:?}: {e:?}"));
+        assert!(rest.is_empty(), "{wire:?}");
+        assert_eq!(frame, build, "{wire:?}");
+    }
+}
+
+#[test]
+fn bare_attribute_still_parses_as_an_attribute() {
+    // Only the in-aggregate position changes. A standalone attribute is
+    // unaffected.
+    let (frame, rest) = resp3::parse_frame(Bytes::from_static(b"|1\r\n+ttl\r\n:3600\r\n")).unwrap();
+    assert!(rest.is_empty());
+    assert_eq!(
+        frame,
+        Frame::Attribute(vec![(
+            Frame::SimpleString(Bytes::from_static(b"ttl")),
+            Frame::Integer(3600)
+        )])
+    );
+}
+
+#[test]
+fn attribute_inside_a_nested_aggregate_does_not_disturb_the_outer_count() {
+    let wire = Bytes::from_static(b"*2\r\n*1\r\n|1\r\n+a\r\n:1\r\n:9\r\n+tail\r\n");
+    let (frame, rest) = resp3::parse_frame(wire).unwrap();
+    assert!(rest.is_empty());
+    assert_eq!(
+        frame,
+        Frame::Array(Some(vec![
+            Frame::Array(Some(vec![Frame::Integer(9)])),
+            Frame::SimpleString(Bytes::from_static(b"tail")),
+        ]))
+    );
+}
+
+#[test]
+fn attribute_does_not_shift_pipelined_reply_boundaries() {
+    // The regression that matters: a stolen slot leaves the real element in the
+    // buffer, where it is returned as the reply to the next command.
+    let mut parser = resp3::Parser::new();
+    parser.feed(Bytes::from_static(
+        b"*3\r\n:1\r\n:2\r\n|1\r\n+ttl\r\n:3600\r\n:3\r\n",
+    ));
+    parser.feed(Bytes::from_static(b"+SECOND\r\n"));
+
+    assert_eq!(
+        parser.next_frame().unwrap().unwrap(),
+        Frame::Array(Some(vec![
+            Frame::Integer(1),
+            Frame::Integer(2),
+            Frame::Integer(3)
+        ]))
+    );
+    assert_eq!(
+        parser.next_frame().unwrap().unwrap(),
+        Frame::SimpleString(Bytes::from_static(b"SECOND"))
+    );
+    assert_eq!(parser.next_frame().unwrap(), None);
+}
+
+#[test]
+fn truncated_attribute_inside_an_aggregate_reports_incomplete() {
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b"*1\r\n|1\r\n+ttl\r\n")),
+        Err(ParseError::Incomplete)
+    );
+}
+
+#[test]
+fn attribute_wrapping_deep_content_respects_max_depth() {
+    // `|` cannot be chained (see NESTING_TAGS), so its depth accounting is
+    // checked by wrapping a deep array: the attribute spends one level and the
+    // array spends the rest.
+    let deep = |levels: usize| {
+        let mut s = String::from("|1\r\n+k\r\n");
+        s.push_str(&"*1\r\n".repeat(levels));
+        s.push_str(":42\r\n");
+        Bytes::from(s)
+    };
+
+    // One attribute plus MAX_DEPTH - 1 arrays is exactly at the limit.
+    let (frame, rest) = resp3::parse_frame(deep(resp3::MAX_DEPTH as usize - 1)).unwrap();
+    assert!(rest.is_empty());
+    // Skipping applies where an element is expected. Here the attribute is the
+    // whole frame, so it is returned as itself with the array as its value.
+    assert!(matches!(frame, Frame::Attribute(_)));
+
+    // One deeper exceeds it.
+    assert_eq!(
+        resp3::parse_frame(deep(resp3::MAX_DEPTH as usize)),
+        Err(ParseError::DepthExceeded)
     );
 }


### PR DESCRIPTION
Closes #59

## Problem

Attributes are not replies. Per the spec they carry out-of-band metadata for the frame that follows, so a conforming decoder reads the attribute, attaches or discards it, and then reads the actual element. `parse_collection` and `parse_pairs` loop exactly `count` times calling `parse_frame_inner`, which returns `Frame::Attribute` as an ordinary frame, so an attribute inside an aggregate eats one of the declared slots.

The consequence is not a malformed tree, it is silent connection desynchronization. Verified against the spec's own example:

```
frame = Array(Some([Integer(1), Integer(2), Attribute([(SimpleString("ttl"), Integer(3600))])]))
rest  = b":3\r\n"   <-- should be empty
```

Pipelined through `Parser`, the real element comes back as the reply to the next command:

```
reply 0: Array([1, 2, Attribute(...)])   <- truncated
reply 1: Integer(3)                      <- reply 0's third element
reply 2: SimpleString("SECOND")          <- everything after is shifted
```

No error is raised anywhere. Command N receives command N-1's data.

## Plan

Attributes are parsed and discarded when they appear where an aggregate element is expected. Element reads go through a helper that consumes any run of leading attributes and returns the first real frame:

```rust
fn parse_element(input: &Bytes, pos: usize, depth: u32) -> Result<(Frame, usize), ParseError> {
    let mut cursor = pos;
    loop {
        let (frame, next) = parse_frame_inner(input, cursor, depth)?;
        cursor = next;
        if !matches!(frame, Frame::Attribute(_)) {
            return Ok((frame, cursor));
        }
    }
}
```

Applied to `parse_collection` (`*` `~` `>`) and to both the key and value reads in `parse_pairs` (`%` `|`).

Discarding rather than attaching is deliberate. Attaching is what redis-protocol 6 does and is more faithful, but it requires a field on every `Frame` variant, which is an API break and grows a type that #53 already wants smaller. Dropping the metadata keeps the fix to the desynchronization, which is the part that corrupts data.

A bare top-level attribute still parses to `Frame::Attribute` exactly as today. Only the in-aggregate position changes.

## Tests

- The spec's example parses to `[1, 2, 3]` with empty `rest`
- Attribute in first, middle, and last element position
- Consecutive attributes before one element
- Attribute before a map key and before a map value
- All five aggregate tags
- The pipelined `Parser` case above, asserting reply boundaries do not shift
- A bare top-level attribute still yields `Frame::Attribute`
- Nested: an attribute inside an inner aggregate does not disturb the outer count

## Known gap

`parse_streaming_sequence` accumulates items from its own `parse_frame` loop and will still push an attribute as an item. Those aggregates are terminator-delimited rather than counted, so there is no slot to steal and no desynchronization, but the item list is still not what the spec implies. Tracked separately rather than widened into this PR.