### PR TITLE
fix(resp3): scalar conformance for null, stream terminator, big number, and the streamed-string terminator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 //! use resp_rs::resp3::{self, Frame};
 //!
 //! // Streaming string: $?\r\n followed by chunks, terminated by ;0\r\n
-//! let data = Bytes::from("$?\r\n;5\r\nHello\r\n;6\r\n World\r\n;0\r\n\r\n");
+//! let data = Bytes::from("$?\r\n;5\r\nHello\r\n;6\r\n World\r\n;0\r\n");
 //! let (frame, _) = resp3::parse_streaming_sequence(data).unwrap();
 //!
 //! if let Frame::StreamedString(chunks) = frame {

--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -637,6 +637,41 @@ fn parse_collection(
     }
 }
 
+/// Check that a tag with no payload is followed by exactly CRLF.
+///
+/// The bounds check and the content check are separate on purpose. Folding them
+/// into one error path reports a complete but invalid frame such as `_x\r\n` as
+/// [`ParseError::Incomplete`], which `Parser` reads as "need more data", so a
+/// peer sending it is never rejected and the parser waits forever.
+#[inline]
+fn check_bare_crlf(buf: &[u8], pos: usize) -> Result<(), ParseError> {
+    if pos + 2 >= buf.len() {
+        return Err(ParseError::Incomplete);
+    }
+    if buf[pos + 1] != b'\r' || buf[pos + 2] != b'\n' {
+        return Err(ParseError::InvalidFormat);
+    }
+    Ok(())
+}
+
+/// Check a big number payload against the grammar: an optional sign followed by
+/// one or more decimal digits.
+///
+/// Without this the arm hands back whatever the line held, and `frame_to_bytes`
+/// re-emits it verbatim, so the crate would both accept and reproduce
+/// non-conforming wire bytes.
+#[inline]
+fn check_big_number(payload: &[u8]) -> Result<(), ParseError> {
+    let digits = match payload.first() {
+        Some(b'+') | Some(b'-') => &payload[1..],
+        _ => payload,
+    };
+    if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+        return Err(ParseError::InvalidFormat);
+    }
+    Ok(())
+}
+
 /// Read one aggregate element, skipping any attributes that precede it.
 ///
 /// An attribute is not a reply. It carries out-of-band metadata for the frame
@@ -716,15 +751,18 @@ fn parse_streamed_chunk(
     if len > MAX_BULK_STRING_SIZE {
         return Err(ParseError::BadLength);
     }
-    let (data_start, data_end) = parse_blob_bounds(buf, after_crlf, len)?;
-    if data_start == data_end {
-        Ok((Frame::StreamedStringChunk(Bytes::new()), after_crlf + 2))
-    } else {
-        Ok((
-            Frame::StreamedStringChunk(input.slice(data_start..data_end)),
-            data_end + 2,
-        ))
+    // A zero-length chunk is the end-of-stream marker and is exactly `;0\r\n`,
+    // four bytes with no payload and no trailing CRLF. This cannot share
+    // `parse_blob_bounds` with `$` and `!`, where a zero length does carry its
+    // own trailing CRLF (`$0\r\n\r\n`).
+    if len == 0 {
+        return Ok((Frame::StreamedStringChunk(Bytes::new()), after_crlf));
     }
+    let (data_start, data_end) = parse_blob_bounds(buf, after_crlf, len)?;
+    Ok((
+        Frame::StreamedStringChunk(input.slice(data_start..data_end)),
+        data_end + 2,
+    ))
 }
 
 /// Offset-based internal parser. The match body is kept minimal to reduce
@@ -774,21 +812,17 @@ pub(crate) fn parse_frame_inner(
         }
         b'(' => {
             let (line_end, after_crlf) = find_crlf(buf, pos + 1)?;
+            let payload = &buf[pos + 1..line_end];
+            check_big_number(payload)?;
             Ok((Frame::BigNumber(input.slice(pos + 1..line_end)), after_crlf))
         }
         b'_' => {
-            if pos + 2 < buf.len() && buf[pos + 1] == b'\r' && buf[pos + 2] == b'\n' {
-                Ok((Frame::Null, pos + 3))
-            } else {
-                Err(ParseError::Incomplete)
-            }
+            check_bare_crlf(buf, pos)?;
+            Ok((Frame::Null, pos + 3))
         }
         b'.' => {
-            if pos + 2 < buf.len() && buf[pos + 1] == b'\r' && buf[pos + 2] == b'\n' {
-                Ok((Frame::StreamTerminator, pos + 3))
-            } else {
-                Err(ParseError::Incomplete)
-            }
+            check_bare_crlf(buf, pos)?;
+            Ok((Frame::StreamTerminator, pos + 3))
         }
 
         // Length-prefixed types (extracted to reduce icache pressure)
@@ -840,7 +874,7 @@ pub use codec_impl::Codec;
 /// use resp_rs::resp3::{parse_streaming_sequence, Frame};
 /// use bytes::Bytes;
 ///
-/// let data = Bytes::from("$?\r\n;4\r\nHell\r\n;6\r\no worl\r\n;1\r\nd\r\n;0\r\n\r\n");
+/// let data = Bytes::from("$?\r\n;4\r\nHell\r\n;6\r\no worl\r\n;1\r\nd\r\n;0\r\n");
 /// let (frame, rest) = parse_streaming_sequence(data).unwrap();
 ///
 /// if let Frame::StreamedString(chunks) = frame {
@@ -1246,8 +1280,12 @@ fn serialize_frame(frame: &Frame, buf: &mut BytesMut) {
             let len = data.len().to_string();
             buf.extend_from_slice(len.as_bytes());
             buf.extend_from_slice(b"\r\n");
-            buf.extend_from_slice(data);
-            buf.extend_from_slice(b"\r\n");
+            // A zero-length chunk is the end-of-stream marker, `;0\r\n`, with
+            // no payload and no trailing CRLF.
+            if !data.is_empty() {
+                buf.extend_from_slice(data);
+                buf.extend_from_slice(b"\r\n");
+            }
         }
         Frame::StreamedString(chunks) => {
             // Serialize as streaming string sequence: $?\r\n + chunks + terminator
@@ -1260,7 +1298,7 @@ fn serialize_frame(frame: &Frame, buf: &mut BytesMut) {
                 buf.extend_from_slice(chunk);
                 buf.extend_from_slice(b"\r\n");
             }
-            buf.extend_from_slice(b";0\r\n\r\n");
+            buf.extend_from_slice(b";0\r\n");
         }
         Frame::StreamedArray(items) => {
             buf.extend_from_slice(b"*?\r\n");
@@ -2063,7 +2101,7 @@ mod tests {
                 Frame::StreamedStringChunk(Bytes::from("o wor")),
             ),
             (";1\r\nd\r\n", Frame::StreamedStringChunk(Bytes::from("d"))),
-            (";0\r\n\r\n", Frame::StreamedStringChunk(Bytes::new())),
+            (";0\r\n", Frame::StreamedStringChunk(Bytes::new())),
             (
                 ";11\r\nHello World\r\n",
                 Frame::StreamedStringChunk(Bytes::from("Hello World")),
@@ -2111,10 +2149,11 @@ mod tests {
         let result = parse_frame(data);
         assert!(matches!(result, Err(ParseError::Incomplete)));
 
-        // Test zero-length chunk without trailing CRLF returns Incomplete
+        // Zero-length chunk is the four-byte end-of-stream marker (#62).
         let data = Bytes::from(";0\r\n");
-        let result = parse_frame(data);
-        assert!(matches!(result, Err(ParseError::Incomplete)));
+        let (frame, rest) = parse_frame(data).unwrap();
+        assert_eq!(frame, Frame::StreamedStringChunk(Bytes::new()));
+        assert!(rest.is_empty());
 
         // Test binary data in chunk
         let binary_data = b"\x00\x01\x02\x03\xFF";
@@ -2140,7 +2179,7 @@ mod tests {
             Bytes::from("ld"),
         ]);
         let serialized = frame_to_bytes(&streaming_string);
-        let expected = "$?\r\n;4\r\nHell\r\n;5\r\no wor\r\n;2\r\nld\r\n;0\r\n\r\n";
+        let expected = "$?\r\n;4\r\nHell\r\n;5\r\no wor\r\n;2\r\nld\r\n;0\r\n";
         assert_eq!(serialized, Bytes::from(expected));
 
         let (parsed, _) = parse_streaming_sequence(serialized).unwrap();
@@ -2174,7 +2213,7 @@ mod tests {
         // Test empty streaming string
         let empty_streaming = Frame::StreamedString(vec![]);
         let serialized = frame_to_bytes(&empty_streaming);
-        let expected = "$?\r\n;0\r\n\r\n";
+        let expected = "$?\r\n;0\r\n";
         assert_eq!(serialized, Bytes::from(expected));
         let (parsed, _) = parse_streaming_sequence(serialized).unwrap();
         assert_eq!(parsed, empty_streaming);
@@ -2292,10 +2331,11 @@ mod tests {
         let result = parse_streaming_sequence(data);
         assert!(matches!(result, Err(ParseError::InvalidFormat)));
 
-        // Test streaming sequence with corrupted terminator
+        // A corrupted terminator is a complete, invalid frame, so it is
+        // rejected rather than reported as truncated (#57).
         let data = Bytes::from("*?\r\n+hello\r\n.corrupted\r\n");
         let result = parse_streaming_sequence(data);
-        assert!(matches!(result, Err(ParseError::Incomplete)));
+        assert!(matches!(result, Err(ParseError::InvalidFormat)));
 
         // Test empty input to parse_streaming_sequence
         let data = Bytes::new();
@@ -2369,20 +2409,33 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_length_streamed_chunk_requires_trailing_crlf() {
-        // Complete: ;0\r\n\r\n
-        let input = Bytes::from(";0\r\n\r\nTAIL");
+    fn test_zero_length_streamed_chunk_is_four_bytes() {
+        // The end-of-stream marker is `;0\r\n`, with no payload and no trailing
+        // CRLF. This test previously asserted the opposite (issue #62): the
+        // chunk type borrowed the zero-length rule from `$` and `!`, where a
+        // zero length does carry its own CRLF.
+        let input = Bytes::from(";0\r\nTAIL");
         let (frame, rest) = parse_frame(input).unwrap();
         assert_eq!(frame, Frame::StreamedStringChunk(Bytes::new()));
         assert_eq!(rest, Bytes::from("TAIL"));
 
-        // Incomplete: ;0\r\n with no trailing data
+        // Consumes exactly four bytes, leaving anything after it alone.
         let input = Bytes::from(";0\r\n");
-        assert_eq!(parse_frame(input), Err(ParseError::Incomplete));
+        let (frame, rest) = parse_frame(input).unwrap();
+        assert_eq!(frame, Frame::StreamedStringChunk(Bytes::new()));
+        assert!(rest.is_empty());
 
-        // Invalid: ;0\r\n followed by non-CRLF
-        let input = Bytes::from(";0\r\nXY");
-        assert_eq!(parse_frame(input), Err(ParseError::InvalidFormat));
+        // Truncated header is still incomplete.
+        assert_eq!(
+            parse_frame(Bytes::from(";0\r")),
+            Err(ParseError::Incomplete)
+        );
+
+        // A non-empty chunk still carries its trailing CRLF.
+        let input = Bytes::from(";2\r\nhi\r\n");
+        let (frame, rest) = parse_frame(input).unwrap();
+        assert_eq!(frame, Frame::StreamedStringChunk(Bytes::from("hi")));
+        assert!(rest.is_empty());
     }
 
     #[test]
@@ -2599,7 +2652,7 @@ mod tests {
     #[test]
     fn test_empty_streaming_containers() {
         // Empty streaming string
-        let data = Bytes::from("$?\r\n;0\r\n\r\n");
+        let data = Bytes::from("$?\r\n;0\r\n");
         let (frame, _) = parse_streaming_sequence(data).unwrap();
         assert_eq!(frame, Frame::StreamedString(vec![]));
 

--- a/src/resp3_unchecked.rs
+++ b/src/resp3_unchecked.rs
@@ -232,7 +232,9 @@ unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
             let cr = find_cr(buf, pos + 1);
             let len = parse_usize_unchecked(buf.get_unchecked(pos + 1..cr));
             if len == 0 {
-                return (Frame::StreamedStringChunk(Bytes::new()), cr + 4);
+                // End-of-stream marker `;0\r\n`: four bytes, no payload and no
+                // trailing CRLF. Must match resp3::parse_streamed_chunk.
+                return (Frame::StreamedStringChunk(Bytes::new()), cr + 2);
             }
             let ds = cr + 2;
             let de = ds + len;
@@ -303,7 +305,7 @@ mod tests {
             "$?\r\n",
             "*?\r\n",
             ";5\r\nhello\r\n",
-            ";0\r\n\r\n",
+            ";0\r\n",
         ];
 
         for wire in cases {

--- a/tests/property.proptest-regressions
+++ b/tests/property.proptest-regressions
@@ -1,8 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 8ba43a40b199497bdac8a780f25d25157fdf2b62950548cbaf67b4b1639573ee # shrinks to frames = [Map([(SimpleString(b""), Attribute([]))])], split_points = [0]
-cc ac9ee17e16b1b946a21e71dacbca33de217b07004b0ecb10edb3bf403f85af25 # shrinks to frame = Set([Attribute([])])

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -50,7 +50,22 @@ fn arb_resp3_frame() -> impl Strategy<Value = resp_rs::resp3::Frame> {
         any::<f64>()
             .prop_filter("finite", |f| f.is_finite())
             .prop_map(Frame::Double),
-        safe_line_bytes().prop_map(|b| Frame::BigNumber(Bytes::from(b))),
+        // A big number is an optional sign followed by one or more decimal
+        // digits (issue #58). Generating arbitrary line bytes here would assert
+        // a round trip the parser does not claim, since it now rejects payloads
+        // that are not big numbers.
+        (
+            prop::option::of(prop_oneof![Just('+'), Just('-')]),
+            prop::collection::vec(prop::num::u8::ANY.prop_map(|b| b'0' + b % 10), 1..40),
+        )
+            .prop_map(|(sign, digits)| {
+                let mut s = String::new();
+                if let Some(c) = sign {
+                    s.push(c);
+                }
+                s.push_str(core::str::from_utf8(&digits).unwrap());
+                Frame::BigNumber(Bytes::from(s))
+            }),
         prop::collection::vec(any::<u8>(), 0..256).prop_map(|b| Frame::BlobError(Bytes::from(b))),
         // VerbatimString: 3-byte format tag + arbitrary content
         (

--- a/tests/resp3.rs
+++ b/tests/resp3.rs
@@ -183,7 +183,7 @@ fn attribute_with_data() {
 
 #[test]
 fn streaming_string() {
-    let wire = Bytes::from("$?\r\n;5\r\nHello\r\n;6\r\n World\r\n;0\r\n\r\n");
+    let wire = Bytes::from("$?\r\n;5\r\nHello\r\n;6\r\n World\r\n;0\r\n");
     let (frame, rest) = resp3::parse_streaming_sequence(wire).unwrap();
     assert!(rest.is_empty());
     match frame {
@@ -815,4 +815,144 @@ fn attribute_wrapping_deep_content_respects_max_depth() {
         resp3::parse_frame(deep(resp3::MAX_DEPTH as usize)),
         Err(ParseError::DepthExceeded)
     );
+}
+
+// --- Scalar conformance (issues #57, #58, #62) ---
+
+#[test]
+fn null_and_terminator_distinguish_truncated_from_invalid() {
+    // Complete but invalid must not be reported as truncated, or Parser waits
+    // forever for data that cannot help.
+    for wire in [
+        &b"_x\r\n"[..],
+        &b"_\r\r\n"[..],
+        &b".x\r\n"[..],
+        &b".\r\r\n"[..],
+    ] {
+        assert_eq!(
+            resp3::parse_frame(Bytes::copy_from_slice(wire)),
+            Err(ParseError::InvalidFormat),
+            "{}",
+            String::from_utf8_lossy(wire)
+        );
+    }
+
+    // Genuinely truncated still reports Incomplete.
+    for wire in [&b"_"[..], &b"_\r"[..], &b"."[..], &b".\r"[..]] {
+        assert_eq!(
+            resp3::parse_frame(Bytes::copy_from_slice(wire)),
+            Err(ParseError::Incomplete),
+            "{}",
+            String::from_utf8_lossy(wire)
+        );
+    }
+
+    // Valid forms unchanged.
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b"_\r\n")).unwrap().0,
+        Frame::Null
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b".\r\n")).unwrap().0,
+        Frame::StreamTerminator
+    );
+}
+
+#[test]
+fn parser_terminates_on_a_malformed_null() {
+    // The regression that matters: Incomplete means "need more data", so a
+    // malformed null previously left the connection with no reason to close.
+    let mut parser = resp3::Parser::new();
+    parser.feed(Bytes::from_static(b"_x\r\n"));
+    assert_eq!(parser.next_frame(), Err(ParseError::InvalidFormat));
+}
+
+#[test]
+fn sibling_scalar_arms_are_unchanged() {
+    // Controls, so the null and terminator fix does not overshoot.
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b"#x\r\n")),
+        Err(ParseError::InvalidBoolean)
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b":x\r\n")),
+        Err(ParseError::InvalidFormat)
+    );
+    assert_eq!(
+        resp3::parse_frame(Bytes::from_static(b"$x\r\n")),
+        Err(ParseError::BadLength)
+    );
+}
+
+#[test]
+fn big_number_requires_optional_sign_then_digits() {
+    for wire in [
+        &b"(\r\n"[..],
+        &b"(not-a-number\r\n"[..],
+        &b"(1.5\r\n"[..],
+        &b"(--1\r\n"[..],
+        &b"( 12\r\n"[..],
+        &b"(+\r\n"[..],
+        &b"(12x\r\n"[..],
+    ] {
+        assert_eq!(
+            resp3::parse_frame(Bytes::copy_from_slice(wire)),
+            Err(ParseError::InvalidFormat),
+            "{}",
+            String::from_utf8_lossy(wire)
+        );
+    }
+
+    // The spec's example, unsigned and signed.
+    for wire in [
+        &b"(3492890328409238509324850943850943825024385\r\n"[..],
+        &b"(+3492890328409238509324850943850943825024385\r\n"[..],
+        &b"(-3492890328409238509324850943850943825024385\r\n"[..],
+        &b"(0\r\n"[..],
+    ] {
+        let (frame, rest) = resp3::parse_frame(Bytes::copy_from_slice(wire))
+            .unwrap_or_else(|e| panic!("{}: {e:?}", String::from_utf8_lossy(wire)));
+        assert!(rest.is_empty());
+        assert!(matches!(frame, Frame::BigNumber(_)));
+    }
+}
+
+#[test]
+fn streamed_string_terminator_is_four_bytes() {
+    // `;0\r\n`, not `;0\r\n\r\n`.
+    let wire = Bytes::from_static(b"$?\r\n;5\r\nHello\r\n;6\r\n World\r\n;0\r\n");
+    let (frame, rest) = resp3::parse_streaming_sequence(wire).unwrap();
+    assert!(rest.is_empty());
+    match frame {
+        Frame::StreamedString(chunks) => {
+            assert_eq!(chunks.len(), 2);
+            assert_eq!(chunks[0], Bytes::from_static(b"Hello"));
+            assert_eq!(chunks[1], Bytes::from_static(b" World"));
+        }
+        other => panic!("expected StreamedString, got {other:?}"),
+    }
+}
+
+#[test]
+fn streamed_string_terminator_round_trips() {
+    let frame = Frame::StreamedString(vec![Bytes::from_static(b"ab"), Bytes::from_static(b"cd")]);
+    let wire = resp3::frame_to_bytes(&frame);
+    assert_eq!(
+        wire,
+        Bytes::from_static(b"$?\r\n;2\r\nab\r\n;2\r\ncd\r\n;0\r\n")
+    );
+
+    let (reparsed, rest) = resp3::parse_streaming_sequence(wire).unwrap();
+    assert!(rest.is_empty());
+    assert_eq!(reparsed, frame);
+}
+
+#[test]
+fn empty_streamed_chunk_serializes_to_four_bytes() {
+    let wire = resp3::frame_to_bytes(&Frame::StreamedStringChunk(Bytes::new()));
+    assert_eq!(wire, Bytes::from_static(b";0\r\n"));
+
+    // A non-empty chunk still carries its trailing CRLF.
+    let wire = resp3::frame_to_bytes(&Frame::StreamedStringChunk(Bytes::from_static(b"hi")));
+    assert_eq!(wire, Bytes::from_static(b";2\r\nhi\r\n"));
 }


### PR DESCRIPTION
Closes #57
Closes #58
Closes #62

Three conformance defects in the RESP3 scalar arms, grouped because they sit in the same `match` and share test surface.

## #57: `_` and `.` fold two conditions into one error

Both arms share a single `else`, so "not enough bytes yet" and "these bytes can never form a null" both report `Incomplete`. `_x\r\n` is a complete, unambiguously invalid 4-byte input that is indistinguishable from the genuinely truncated `_`.

That matters beyond classification: `Parser` treats `Incomplete` as "need more data", so a peer sending `_x` is never rejected and the parser waits forever. Same failure mode as the fail-fast regression caught in #52 review.

Every sibling arm already rejects its malformed form: `#` returns `InvalidBoolean`, `:` goes through `parse_i64`, `$` through `parse_bulk_string`.

## #58: `(` performs no grammar validation

The big-number arm hands back the whole line unchecked, so `(not-a-number`, `(1.5`, `(--1`, `( 12`, and the empty `(\r\n` all parse. Worse, `frame_to_bytes` re-emits them verbatim, so the crate both accepts and reproduces non-conforming wire bytes.

Validation is an optional `+` or `-` followed by one or more decimal digits.

## #62: streamed-string terminator is 4 bytes, not 6

RESP3 ends a streamed string with `;0\r\n`. The crate requires and emits `;0\r\n\r\n` because `parse_streamed_chunk` routes `;` through `parse_blob_bounds`, which is shared with `$` and `!` where a zero length genuinely does carry its own trailing CRLF.

Three places carry the off-by-two: the parser via `parse_blob_bounds`, the serializer in both the `StreamedString` terminator and the `StreamedStringChunk(empty)` arm, and the unchecked parser's `;` arm.

This one changes bytes on the wire, so it is the only behaviour change here that a downstream consumer could notice. Existing tests and doc examples that spell the terminator `;0\r\n\r\n` are updated.

## Plan

- Split the bounds check from the content check in the `_` and `.` arms, returning `Incomplete` only when bytes are genuinely missing and `InvalidFormat` when present bytes cannot form the frame.
- Validate the big-number payload in the `(` arm.
- Give `;` its own zero-length handling rather than borrowing the blob rule, and correct the two serializer sites and the unchecked arm to match.

## Tests

Per issue, including the full classification tables from #57 and #58, the sibling arms as controls so the fix does not overshoot, `Parser` termination for `_x`, a streamed-string round trip on the corrected 4-byte terminator, and unchecked-vs-safe equivalence on the `;` arm.

Also removes `tests/property.proptest-regressions`. Both seeds in it record `Attribute` nested inside an aggregate, which the generator stopped producing in #66 because the parser cannot produce it either. They captured a failure of an intermediate generator, not of shipped code.