### PR TITLE
fix(unsafe-internals): find_cr must agree with find_crlf on a bare CR

### DIFF
--- a/src/resp2_unchecked.rs
+++ b/src/resp2_unchecked.rs
@@ -12,18 +12,26 @@ use bytes::Bytes;
 
 use crate::resp2::Frame;
 
-/// Find `\r` in buf starting at `from` using unchecked pointer access.
+/// Find the CRLF terminating a line, starting at `from`, using unchecked
+/// pointer access. Returns the position of the `\r`.
+///
+/// This scans for the `\r\n` pair, not for a bare `\r`. It must agree with the
+/// safe [`crate::resp2::find_crlf`], which treats a lone `\r` inside a payload
+/// as ordinary data. Stopping at the first `\r` would end the line early on
+/// input the safe parser accepts, desynchronizing the cursor and resuming on a
+/// byte that is not a frame tag.
 ///
 /// # Safety
 ///
-/// Caller must ensure `buf[from..]` contains a `\r` byte before the end
-/// of the allocation.
+/// Caller must ensure `buf[from..]` contains a `\r\n` pair before the end of
+/// the allocation.
 #[inline(always)]
 unsafe fn find_cr(buf: &[u8], from: usize) -> usize {
     let ptr = buf.as_ptr();
     let mut i = from;
-    // SAFETY: caller guarantees a \r exists in bounds
-    while *ptr.add(i) != b'\r' {
+    // SAFETY: caller guarantees a CRLF exists in bounds, at some index j with
+    // j + 1 in bounds. The loop only reads i + 1 while i < j, so i + 1 <= j.
+    while !(*ptr.add(i) == b'\r' && *ptr.add(i + 1) == b'\n') {
         i += 1;
     }
     i
@@ -188,6 +196,14 @@ mod tests {
             "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
             "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n",
             "*2\r\n*1\r\n:1\r\n+OK\r\n",
+            // Bare CR inside a payload is data, not a line terminator. These
+            // desynchronized the unchecked cursor before issue #65: the first
+            // gave a silently wrong result, the second reached
+            // unreachable_unchecked and aborted.
+            "+a\rb\r\n",
+            "-a\rb\r\n",
+            "*2\r\n+a\rZ+b\r\n+x\r\n",
+            "*2\r\n+a\rb\r\n+x\r\n",
         ];
 
         for wire in cases {

--- a/src/resp3_unchecked.rs
+++ b/src/resp3_unchecked.rs
@@ -12,11 +12,23 @@ use bytes::Bytes;
 
 use crate::resp3::Frame;
 
+/// Find the CRLF terminating a line, starting at `from`. Returns the position
+/// of the `\r`.
+///
+/// Scans for the `\r\n` pair, not a bare `\r`, so that it agrees with the safe
+/// [`crate::resp3::find_crlf`]. See the RESP2 counterpart for the reasoning.
+///
+/// # Safety
+///
+/// Caller must ensure `buf[from..]` contains a `\r\n` pair before the end of
+/// the allocation.
 #[inline(always)]
 unsafe fn find_cr(buf: &[u8], from: usize) -> usize {
     let ptr = buf.as_ptr();
     let mut i = from;
-    while *ptr.add(i) != b'\r' {
+    // SAFETY: caller guarantees a CRLF exists in bounds, at some index j with
+    // j + 1 in bounds. The loop only reads i + 1 while i < j, so i + 1 <= j.
+    while !(*ptr.add(i) == b'\r' && *ptr.add(i + 1) == b'\n') {
         i += 1;
     }
     i
@@ -306,6 +318,10 @@ mod tests {
             "*?\r\n",
             ";5\r\nhello\r\n",
             ";0\r\n",
+            // Bare CR inside a payload is data, not a line terminator (#65).
+            "+a\rb\r\n",
+            "-a\rb\r\n",
+            "*2\r\n+a\rZ+b\r\n+x\r\n",
         ];
 
         for wire in cases {

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -5,11 +5,17 @@ use proptest::prelude::*;
 // Arbitrary frame generators
 // ---------------------------------------------------------------------------
 
-/// Generate a byte string that is safe for RESP simple strings / errors
-/// (no \r or \n characters).
+/// Generate a byte string that is safe for RESP simple strings / errors.
+///
+/// Only `\n` is excluded. A payload with no `\n` cannot contain `\r\n`, so it
+/// cannot terminate its own line, which is the actual constraint. A bare `\r`
+/// is ordinary payload data and is deliberately included: excluding it also
+/// excluded the only byte on which the safe and unchecked parsers disagreed
+/// (issue #65), so the equivalence properties were asserting equivalence over
+/// an alphabet chosen to omit the counterexample.
 fn safe_line_bytes() -> impl Strategy<Value = Vec<u8>> {
     prop::collection::vec(
-        prop::num::u8::ANY.prop_filter("no CR/LF", |b| *b != b'\r' && *b != b'\n'),
+        prop::num::u8::ANY.prop_filter("no LF", |b| *b != b'\n'),
         0..128,
     )
 }


### PR DESCRIPTION
Closes #65

## Problem

`find_cr` in the unchecked parsers stops at the first `\r`. `find_crlf` in the safe parsers stops only at a `\r` immediately followed by `\n`. A bare `\r` inside a line payload is therefore ordinary data to one and a terminator to the other.

That breaks the documented safety contract. Both `parse_frame_unchecked` functions tell the caller that validating with `parse_frame` first is sufficient, with bounded nesting depth as the only remaining obligation. It is not: `parse_frame` returns `Ok` on input containing a bare `\r`, and the unchecked parser then desynchronizes inside the frame and resumes on a byte that is not a tag.

Reproduced in the issue at three severities on input `parse_frame` accepts: a silently wrong result, a non-unwinding abort via `unreachable_unchecked`, and in release a bogus allocation of 9,244,448,444,443,520 bytes.

Every `find_cr` caller is affected: `+` `-` `:` `$` `*` in RESP2, plus `(` `,` `#` `!` `=` `%` `~` `>` in RESP3.

## Plan

Make `find_cr` scan for the CRLF pair, matching `find_crlf`:

```rust
while !(*ptr.add(i) == b'\r' && *ptr.add(i + 1) == b'\n') {
    i += 1;
}
```

Reading `i + 1` stays in bounds under the existing precondition. The caller guarantees a complete frame, so a CRLF exists at some index `j` with `j + 1 < len`; the loop only reads `i + 1` for `i < j`, and `i + 1 <= j`.

## Why the equivalence property never caught this

`tests/property.rs::safe_line_bytes` filters out both `\r` and `\n`, so the generator cannot produce the one byte that separates the two implementations. `resp2_unchecked_matches_safe` and `resp3_unchecked_matches_safe` have been asserting equivalence over an alphabet chosen to exclude the counterexample.

Excluding `\n` alone is sufficient to keep a payload from containing `\r\n`, so the filter is loosened to permit a bare `\r`. That makes the existing equivalence properties able to find this class on their own.

This is the same shape as #49 and #58: the generator was closed under the implementation's assumptions rather than derived from the grammar.

## Tests

- Direct equivalence on the issue's three inputs, safe versus unchecked
- A bare `\r` in each line-based type across both protocols
- The loosened property generator, which reaches this without a hand-written case