### PR TITLE
fix: cap CRLF-terminated line length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,4 +460,10 @@ pub enum ParseError {
     /// See [`resp2::MAX_DEPTH`] and [`resp3::MAX_DEPTH`].
     #[error("maximum nesting depth exceeded")]
     DepthExceeded,
+
+    /// A CRLF-terminated line exceeded the parser's length limit.
+    ///
+    /// See [`resp2::MAX_LINE_LENGTH`] and [`resp3::MAX_LINE_LENGTH`].
+    #[error("maximum line length exceeded")]
+    LineTooLong,
 }

--- a/src/resp2.rs
+++ b/src/resp2.rs
@@ -63,6 +63,26 @@ const PREALLOC_CAP: usize = 128;
 /// reachable by real traffic.
 pub const MAX_DEPTH: u32 = 128;
 
+/// Maximum length of a single CRLF-terminated line.
+///
+/// Line-based prefixes are scanned forward for `\r\n`. Without a ceiling a peer
+/// that sends a tag and never sends the terminator holds the parser in
+/// `Incomplete` forever: [`Parser`] keeps buffering, and because it re-parses
+/// from offset 0 on every call, the rescan cost is quadratic in what has
+/// arrived. Neither existing limit applies, because `MAX_COLLECTION_SIZE` and
+/// `MAX_BULK_STRING_SIZE` bound counts and lengths that are only read once the
+/// line has terminated.
+///
+/// A line past this limit is rejected with [`ParseError::LineTooLong`], which is
+/// a hard error, so [`Parser`] drops the buffer rather than waiting for data
+/// that cannot help.
+///
+/// 64 KiB matches Redis's own `PROTO_INLINE_MAX_SIZE`. Every line-based type
+/// here is a status string, an error message, or a run of digits, so real
+/// traffic is orders of magnitude below it; large payloads travel as bulk
+/// strings, whose body is length-prefixed and not scanned for CRLF.
+pub const MAX_LINE_LENGTH: usize = 64 * 1024;
+
 /// A parsed RESP2 frame.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Frame {
@@ -418,13 +438,24 @@ impl Parser {
 /// `line_end` is the position of `\r` and `after_crlf` is the position after `\n`.
 #[inline]
 fn find_crlf(buf: &[u8], from: usize) -> Result<(usize, usize), ParseError> {
-    let mut i = from;
     let len = buf.len();
+    let mut i = from;
     while i + 1 < len {
         if buf[i] == b'\r' && buf[i + 1] == b'\n' {
             return Ok((i, i + 2));
         }
         i += 1;
+    }
+    // Only reached when the whole buffer held no CRLF, so the length check
+    // costs nothing on the success path. Bounding the scan itself instead
+    // measured 2 to 4 percent slower on RESP2 array parsing, for a limit that
+    // only ever matters when a frame does not terminate.
+    if len - from > MAX_LINE_LENGTH {
+        // The line already exceeds the ceiling, so no CRLF that arrives later
+        // could bring it back into range. Reporting that rather than
+        // `Incomplete` is what lets `Parser` drop the buffer instead of growing
+        // it for as long as the peer keeps sending.
+        return Err(ParseError::LineTooLong);
     }
     Err(ParseError::Incomplete)
 }

--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -65,6 +65,26 @@ const PREALLOC_CAP: usize = 128;
 /// reachable by real traffic.
 pub const MAX_DEPTH: u32 = 128;
 
+/// Maximum length of a single CRLF-terminated line.
+///
+/// Line-based prefixes are scanned forward for `\r\n`. Without a ceiling a peer
+/// that sends a tag and never sends the terminator holds the parser in
+/// `Incomplete` forever: [`Parser`] keeps buffering, and because it re-parses
+/// from offset 0 on every call, the rescan cost is quadratic in what has
+/// arrived. Neither existing limit applies, because `MAX_COLLECTION_SIZE` and
+/// `MAX_BULK_STRING_SIZE` bound counts and lengths that are only read once the
+/// line has terminated.
+///
+/// A line past this limit is rejected with [`ParseError::LineTooLong`], which is
+/// a hard error, so [`Parser`] drops the buffer rather than waiting for data
+/// that cannot help.
+///
+/// 64 KiB matches Redis's own `PROTO_INLINE_MAX_SIZE`. Every line-based type
+/// here is a status string, an error message, or a run of digits, so real
+/// traffic is orders of magnitude below it; large payloads travel as bulk
+/// strings, whose body is length-prefixed and not scanned for CRLF.
+pub const MAX_LINE_LENGTH: usize = 64 * 1024;
+
 /// A streaming parser for RESP3 frames.
 ///
 /// This parser allows feeding data in chunks and extracting frames as they become available.
@@ -1089,13 +1109,24 @@ pub fn parse_streaming_sequence(input: Bytes) -> Result<(Frame, Bytes), ParseErr
 /// `line_end` is the position of `\r` and `after_crlf` is the position after `\n`.
 #[inline]
 fn find_crlf(buf: &[u8], from: usize) -> Result<(usize, usize), ParseError> {
-    let mut i = from;
     let len = buf.len();
+    let mut i = from;
     while i + 1 < len {
         if buf[i] == b'\r' && buf[i + 1] == b'\n' {
             return Ok((i, i + 2));
         }
         i += 1;
+    }
+    // Only reached when the whole buffer held no CRLF, so the length check
+    // costs nothing on the success path. Bounding the scan itself instead
+    // measured 2 to 4 percent slower on RESP2 array parsing, for a limit that
+    // only ever matters when a frame does not terminate.
+    if len - from > MAX_LINE_LENGTH {
+        // The line already exceeds the ceiling, so no CRLF that arrives later
+        // could bring it back into range. Reporting that rather than
+        // `Incomplete` is what lets `Parser` drop the buffer instead of growing
+        // it for as long as the peer keeps sending.
+        return Err(ParseError::LineTooLong);
     }
     Err(ParseError::Incomplete)
 }

--- a/tests/resp2.rs
+++ b/tests/resp2.rs
@@ -466,3 +466,73 @@ fn lengths_and_counts_still_reject_a_plus() {
         Err(ParseError::BadLength)
     );
 }
+
+// --- Line length ceiling (issue #63) ---
+
+#[test]
+fn unterminated_line_is_rejected_not_buffered_forever() {
+    // Every line-based prefix. Without a ceiling these all returned Incomplete,
+    // which Parser reads as "need more data", so the peer could grow the buffer
+    // without bound.
+    for tag in ["+", "-", ":", "$", "*"] {
+        let mut wire = tag.to_string();
+        wire.push_str(&"x".repeat(resp2::MAX_LINE_LENGTH + 1));
+        assert_eq!(
+            resp2::parse_frame(Bytes::from(wire)),
+            Err(ParseError::LineTooLong),
+            "tag {tag}"
+        );
+    }
+}
+
+#[test]
+fn a_line_at_the_limit_still_parses() {
+    // The ceiling must not reject anything a peer could legitimately send just
+    // under it.
+    let mut wire = String::from("+");
+    wire.push_str(&"y".repeat(resp2::MAX_LINE_LENGTH));
+    wire.push_str("\r\n");
+    let (frame, rest) = resp2::parse_frame(Bytes::from(wire)).unwrap();
+    assert!(rest.is_empty());
+    assert_eq!(frame.as_bytes().unwrap().len(), resp2::MAX_LINE_LENGTH);
+}
+
+#[test]
+fn a_short_unterminated_line_is_still_incomplete() {
+    // Under the ceiling, "not yet" must still be reported as Incomplete so
+    // streaming works.
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b"+partial")),
+        Err(ParseError::Incomplete)
+    );
+    assert_eq!(
+        resp2::parse_frame(Bytes::from_static(b"+partial\r")),
+        Err(ParseError::Incomplete)
+    );
+}
+
+#[test]
+fn parser_stops_buffering_an_unterminated_line() {
+    let mut parser = resp2::Parser::new();
+    parser.feed(Bytes::from_static(b"+"));
+
+    let mut fed = 1usize;
+    for _ in 0..64 {
+        parser.feed(Bytes::from(vec![b'x'; 8192]));
+        fed += 8192;
+        match parser.next_frame() {
+            Ok(None) => continue,
+            Err(ParseError::LineTooLong) => {
+                // Hard error, so the buffer is dropped rather than retained.
+                assert_eq!(parser.buffered_bytes(), 0);
+                assert!(
+                    fed < resp2::MAX_LINE_LENGTH * 2,
+                    "kept buffering to {fed} bytes"
+                );
+                return;
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+    panic!("parser never stopped buffering");
+}

--- a/tests/resp3.rs
+++ b/tests/resp3.rs
@@ -956,3 +956,43 @@ fn empty_streamed_chunk_serializes_to_four_bytes() {
     let wire = resp3::frame_to_bytes(&Frame::StreamedStringChunk(Bytes::from_static(b"hi")));
     assert_eq!(wire, Bytes::from_static(b";2\r\nhi\r\n"));
 }
+
+// --- Line length ceiling (issue #63) ---
+
+#[test]
+fn unterminated_line_is_rejected_for_every_line_type() {
+    for tag in [
+        "+", "-", ":", "(", ",", "#", "!", "=", "$", "*", "%", "~", ">",
+    ] {
+        let mut wire = tag.to_string();
+        wire.push_str(&"x".repeat(resp3::MAX_LINE_LENGTH + 1));
+        assert_eq!(
+            resp3::parse_frame(Bytes::from(wire)),
+            Err(ParseError::LineTooLong),
+            "tag {tag}"
+        );
+    }
+}
+
+#[test]
+fn a_line_at_the_limit_still_parses() {
+    let mut wire = String::from("+");
+    wire.push_str(&"y".repeat(resp3::MAX_LINE_LENGTH));
+    wire.push_str("\r\n");
+    let (frame, rest) = resp3::parse_frame(Bytes::from(wire)).unwrap();
+    assert!(rest.is_empty());
+    assert!(matches!(frame, Frame::SimpleString(ref b) if b.len() == resp3::MAX_LINE_LENGTH));
+}
+
+#[test]
+fn bulk_string_body_is_not_subject_to_the_line_ceiling() {
+    // The ceiling applies to CRLF-scanned lines. A bulk string body is
+    // length-prefixed and read directly, so large payloads still work.
+    let body = vec![b'z'; resp3::MAX_LINE_LENGTH * 4];
+    let mut wire = format!("${}\r\n", body.len()).into_bytes();
+    wire.extend_from_slice(&body);
+    wire.extend_from_slice(b"\r\n");
+    let (frame, rest) = resp3::parse_frame(Bytes::from(wire)).unwrap();
+    assert!(rest.is_empty());
+    assert!(matches!(frame, Frame::BulkString(Some(ref b)) if b.len() == body.len()));
+}


### PR DESCRIPTION
Closes #63

## Problem

`find_crlf` scanned forward for `\r\n` with no upper bound and returned `Incomplete` on running off the end. A peer that sends a type tag and never sends the terminator held the parser there indefinitely.

Two consequences from that one missing ceiling:

1. **Memory.** `Parser::feed` appends with no cap and `next_frame` restores the whole buffer on `Incomplete`, so it grows to whatever the peer sends.
2. **CPU.** `next_frame` re-parses from offset 0 every call, so a line delivered in N chunks costs O(N²) bytes scanned.

No existing limit applied. `MAX_COLLECTION_SIZE` and `MAX_BULK_STRING_SIZE` bound declared counts and lengths, which are read only *after* the length line terminates; when that line never terminates the digits are never parsed. Depth stays at 0 and no aggregate is allocated, so neither `MAX_DEPTH` (#48) nor `bounded_capacity` (#52) is engaged.

## Fix

`find_crlf` scans at most `MAX_LINE_LENGTH` past its start and reports the new `ParseError::LineTooLong`. That is a hard error, so `Parser` drops the buffer instead of waiting for data that cannot help.

The truncated-versus-invalid distinction is exact, which is the same property #52 and #57 turned on:

```rust
if len > last_cr {
    return Err(ParseError::LineTooLong);
}
Err(ParseError::Incomplete)
```

A byte existing at or past the last position a `\r` could occupy means no CRLF can still arrive in range. Below that, `Incomplete` is still returned and streaming is unaffected.

`MAX_LINE_LENGTH` is 64 KiB, matching Redis's `PROTO_INLINE_MAX_SIZE`, and is public alongside `MAX_DEPTH`. Every line-based type is a status string, an error message, or a run of digits. Bulk string bodies are length-prefixed and read directly rather than scanned, so large payloads are untouched.

## Verification

Every line-based prefix in both protocols, 4 MB of non-CRLF payload after the tag:

| Protocol | Prefixes | Before | After |
| --- | --- | --- | --- |
| RESP2 | `+` `-` `:` `$` `*` | `Incomplete` | `LineTooLong` |
| RESP3 | `+` `-` `:` `(` `,` `#` `!` `=` `$` `*` `%` `~` `>` | `Incomplete` | `LineTooLong` |

Through the documented feed/next_frame loop the parser now stops after roughly 64 KB with `buffered_bytes()` back to 0, where it previously grew past 32 MB.

289 tests pass. Boundary cases are pinned in both directions: a line of exactly `MAX_LINE_LENGTH` still parses, a short unterminated line is still `Incomplete`, and a bulk string body four times the ceiling is unaffected.

## Compatibility

This rejects input that previously parsed: a simple string or error longer than 64 KiB. Redis sends long payloads as bulk strings, so real traffic is orders of magnitude below the ceiling, but it is a behaviour change rather than a pure hardening.

`ParseError` gains a variant. That is not breaking now, since `#[non_exhaustive]` landed in #48.
## Benchmarks

The check is deferred to the point where the scan has already failed to find a CRLF anywhere in the buffer, so a complete frame never reaches it.

Bounding the scan itself was measured first and was not free:

| Benchmark | main | bounded scan | deferred check |
| --- | --- | --- | --- |
| `resp2/array_3` | 50.9 ns | 52.8 ns (+3.7%) | 51.2 ns (+0.6%) |
| `resp2/array_100` | 834.6 ns | 850.9 ns (+2.0%) | 837.5 ns (+0.4%) |
| `resp3/array_3` | 101.3 ns | 101.6 ns (+0.2%) | 101.3 ns (-0.1%) |
| `resp3/array_100` | 1360 ns | 1367 ns (+0.5%) | 1364 ns (+0.3%) |

RESP2 paid more than RESP3 under the bounded scan because its `parse_frame_inner` is a small inline match where `find_crlf` is a large fraction of the work, while RESP3 dispatches to `#[inline(never)]` helpers. Deferring removes the cost from both.

Measured at load average under 4, 12s windows, main and branch run back to back with an identical filter.