### PR TITLE
fix: apply the line ceiling to terminated lines too

### DIFF
--- a/src/resp2.rs
+++ b/src/resp2.rs
@@ -73,9 +73,9 @@ pub const MAX_DEPTH: u32 = 128;
 /// `MAX_BULK_STRING_SIZE` bound counts and lengths that are only read once the
 /// line has terminated.
 ///
-/// A line past this limit is rejected with [`ParseError::LineTooLong`], which is
-/// a hard error, so [`Parser`] drops the buffer rather than waiting for data
-/// that cannot help.
+/// A line past this limit is rejected with [`ParseError::LineTooLong`] whether or
+/// not it has terminated. That is a hard error, so [`Parser`] drops the buffer
+/// rather than waiting for data that cannot help.
 ///
 /// 64 KiB matches Redis's own `PROTO_INLINE_MAX_SIZE`. Every line-based type
 /// here is a status string, an error message, or a run of digits, so real
@@ -442,17 +442,20 @@ fn find_crlf(buf: &[u8], from: usize) -> Result<(usize, usize), ParseError> {
     let mut i = from;
     while i + 1 < len {
         if buf[i] == b'\r' && buf[i + 1] == b'\n' {
+            // Enforced on the terminated path too, not just the unterminated
+            // one, so the limit means the same thing either way. This is a
+            // single predictable compare; bounding the scan itself instead
+            // measured 2 to 4 percent slower on RESP2 array parsing.
+            if i - from > MAX_LINE_LENGTH {
+                return Err(ParseError::LineTooLong);
+            }
             return Ok((i, i + 2));
         }
         i += 1;
     }
-    // Only reached when the whole buffer held no CRLF, so the length check
-    // costs nothing on the success path. Bounding the scan itself instead
-    // measured 2 to 4 percent slower on RESP2 array parsing, for a limit that
-    // only ever matters when a frame does not terminate.
     if len - from > MAX_LINE_LENGTH {
-        // The line already exceeds the ceiling, so no CRLF that arrives later
-        // could bring it back into range. Reporting that rather than
+        // Already past the ceiling with no terminator, so no CRLF arriving
+        // later could bring it back into range. Reporting that rather than
         // `Incomplete` is what lets `Parser` drop the buffer instead of growing
         // it for as long as the peer keeps sending.
         return Err(ParseError::LineTooLong);

--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -75,9 +75,9 @@ pub const MAX_DEPTH: u32 = 128;
 /// `MAX_BULK_STRING_SIZE` bound counts and lengths that are only read once the
 /// line has terminated.
 ///
-/// A line past this limit is rejected with [`ParseError::LineTooLong`], which is
-/// a hard error, so [`Parser`] drops the buffer rather than waiting for data
-/// that cannot help.
+/// A line past this limit is rejected with [`ParseError::LineTooLong`] whether or
+/// not it has terminated. That is a hard error, so [`Parser`] drops the buffer
+/// rather than waiting for data that cannot help.
 ///
 /// 64 KiB matches Redis's own `PROTO_INLINE_MAX_SIZE`. Every line-based type
 /// here is a status string, an error message, or a run of digits, so real
@@ -1113,17 +1113,20 @@ fn find_crlf(buf: &[u8], from: usize) -> Result<(usize, usize), ParseError> {
     let mut i = from;
     while i + 1 < len {
         if buf[i] == b'\r' && buf[i + 1] == b'\n' {
+            // Enforced on the terminated path too, not just the unterminated
+            // one, so the limit means the same thing either way. This is a
+            // single predictable compare; bounding the scan itself instead
+            // measured 2 to 4 percent slower on RESP2 array parsing.
+            if i - from > MAX_LINE_LENGTH {
+                return Err(ParseError::LineTooLong);
+            }
             return Ok((i, i + 2));
         }
         i += 1;
     }
-    // Only reached when the whole buffer held no CRLF, so the length check
-    // costs nothing on the success path. Bounding the scan itself instead
-    // measured 2 to 4 percent slower on RESP2 array parsing, for a limit that
-    // only ever matters when a frame does not terminate.
     if len - from > MAX_LINE_LENGTH {
-        // The line already exceeds the ceiling, so no CRLF that arrives later
-        // could bring it back into range. Reporting that rather than
+        // Already past the ceiling with no terminator, so no CRLF arriving
+        // later could bring it back into range. Reporting that rather than
         // `Incomplete` is what lets `Parser` drop the buffer instead of growing
         // it for as long as the peer keeps sending.
         return Err(ParseError::LineTooLong);

--- a/tests/resp2.rs
+++ b/tests/resp2.rs
@@ -536,3 +536,18 @@ fn parser_stops_buffering_an_unterminated_line() {
     }
     panic!("parser never stopped buffering");
 }
+
+#[test]
+fn an_over_long_line_is_rejected_even_when_terminated() {
+    // The ceiling must mean the same thing whether or not the line ends. An
+    // earlier revision only checked the unterminated path, so a complete but
+    // over-long line slipped through and the constant did not mean what its
+    // documentation said.
+    let mut wire = String::from("+");
+    wire.push_str(&"x".repeat(resp2::MAX_LINE_LENGTH + 1));
+    wire.push_str("\r\n");
+    assert_eq!(
+        resp2::parse_frame(Bytes::from(wire)),
+        Err(ParseError::LineTooLong)
+    );
+}

--- a/tests/resp3.rs
+++ b/tests/resp3.rs
@@ -996,3 +996,22 @@ fn bulk_string_body_is_not_subject_to_the_line_ceiling() {
     assert!(rest.is_empty());
     assert!(matches!(frame, Frame::BulkString(Some(ref b)) if b.len() == body.len()));
 }
+
+#[test]
+fn an_over_long_line_is_rejected_even_when_terminated() {
+    // See the RESP2 counterpart: the ceiling applies to terminated lines too.
+    let mut wire = String::from("+");
+    wire.push_str(&"x".repeat(resp3::MAX_LINE_LENGTH + 1));
+    wire.push_str("\r\n");
+    assert_eq!(
+        resp3::parse_frame(Bytes::from(wire)),
+        Err(ParseError::LineTooLong)
+    );
+
+    // A bulk string body is length-prefixed, not scanned, so it stays exempt.
+    let body = vec![b'z'; resp3::MAX_LINE_LENGTH * 4];
+    let mut wire = format!("${}\r\n", body.len()).into_bytes();
+    wire.extend_from_slice(&body);
+    wire.extend_from_slice(b"\r\n");
+    assert!(resp3::parse_frame(Bytes::from(wire)).is_ok());
+}


### PR DESCRIPTION
Follow-up to #69, which I got wrong.

## What happened

#69 moved the length check to the point where the scan had already failed to find a CRLF anywhere in the buffer. I described that as a performance change. It was also a semantic change: an over-long line that *did* terminate was accepted.

```
Frame::SimpleString(100_000 bytes)  ->  parses fine
```

while the constant's own documentation said "a line past this limit is rejected".

## Why the tests missed it

They could not tell the two implementations apart:

| Test | Input | Bounded scan | Deferred check |
| --- | --- | --- | --- |
| `a_line_at_the_limit_still_parses` | exactly `MAX_LINE_LENGTH`, terminated | accept | accept |
| `unterminated_line_is_rejected_not_buffered_forever` | `MAX + 1`, no CRLF | reject | reject |

Nothing covered `MAX + 1` **with** a terminator, which is the only place they differ. Both implementations pass both tests, so the suite certified a behaviour change as a no-op.

## Fix

Check the length on the terminated path as well. That is one predictable compare at the point the CRLF is found, rather than bounding the scan loop.

| Benchmark | main | this | delta |
| --- | --- | --- | --- |
| `resp2/simple_string` | 12.412 ns | 12.456 ns | +0.4% |
| `resp2/error` | 16.309 ns | 16.729 ns | +2.6% |
| `resp2/array_3` | 51.503 ns | 51.712 ns | +0.4% |
| `resp3/simple_string` | 40.694 ns | 40.270 ns | -1.0% |
| `resp3/error` | 42.723 ns | 42.809 ns | +0.2% |
| `resp3/array_3` | 102.24 ns | 101.44 ns | -0.8% |

Mixed signs, so within noise. Bounding the scan cost 2 to 4 percent on RESP2 by comparison.

The doc comment now states that the ceiling applies whether or not the line terminated. New tests in both protocols cover the terminated over-long case and fail against merged #69. A bulk string body four times the ceiling stays exempt, since it is length-prefixed rather than scanned.