### PR TITLE
fix: add checked serialization and wire it into the codec encode path

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,13 +1,22 @@
 //! Shared types for the Tokio codec integration.
 
-use crate::ParseError;
+use crate::{ParseError, SerializeError};
 
 /// Error type for codec operations, wrapping both parse errors and I/O errors.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CodecError {
     /// A RESP protocol parsing error.
     #[error(transparent)]
     Parse(#[from] ParseError),
+
+    /// A frame that cannot be represented on the wire.
+    ///
+    /// `encode` validates before writing, so a frame carrying a CRLF in a line
+    /// payload, or otherwise unable to parse back as itself, is refused rather
+    /// than emitted. See [`SerializeError`].
+    #[error(transparent)]
+    Serialize(#[from] SerializeError),
 
     /// An I/O error from the underlying transport.
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,3 +467,50 @@ pub enum ParseError {
     #[error("maximum line length exceeded")]
     LineTooLong,
 }
+
+/// Reasons a [`Frame`](resp2::Frame) cannot be represented on the wire.
+///
+/// Returned by [`resp2::try_frame_to_bytes`] and [`resp3::try_frame_to_bytes`].
+/// Each variant corresponds to a way the serializer would otherwise emit bytes
+/// that the parser rejects, or reads back as a different frame.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum SerializeError {
+    /// A line-based payload contains a CRLF, which would terminate the frame
+    /// early and let the remainder be read as further frames.
+    ///
+    /// A bare `\r` is fine: the parser scans for the pair, so a lone `\r`
+    /// round-trips as payload.
+    #[error("line payload contains CRLF, which would split the frame")]
+    LineContainsCrlf,
+
+    /// A big number is not an optional sign followed by one or more digits.
+    #[error("big number must be an optional sign followed by digits")]
+    InvalidBigNumber,
+
+    /// A special float is not exactly `inf`, `-inf`, or `nan`.
+    #[error("special float must be exactly inf, -inf, or nan")]
+    InvalidSpecialFloat,
+
+    /// A double is not finite. Non-finite values serialize to spellings the
+    /// parser reads back as a `SpecialFloat`, so they change type on the way
+    /// round.
+    #[error("double must be finite; use SpecialFloat for inf and nan")]
+    NonFiniteDouble,
+
+    /// A verbatim string format tag is not exactly three bytes, or contains a
+    /// colon. The parser requires the separator at index 3 exactly.
+    #[error("verbatim string format must be exactly 3 bytes with no colon")]
+    InvalidVerbatimFormat,
+
+    /// A streamed string contains an empty chunk. An empty chunk is the
+    /// end-of-stream marker, so it would truncate the stream in place.
+    #[error("streamed string chunk is empty, which would terminate the stream")]
+    EmptyStreamedChunk,
+
+    /// An attribute appears where an aggregate element is expected. Attributes
+    /// carry metadata for the frame that follows and do not occupy a slot, so
+    /// the parser skips them and the aggregate comes back one element short.
+    #[error("attribute cannot occupy an aggregate element slot")]
+    AttributeInAggregate,
+}

--- a/src/resp2.rs
+++ b/src/resp2.rs
@@ -26,7 +26,7 @@ use alloc::vec::Vec;
 
 use bytes::{BufMut, Bytes, BytesMut};
 
-use crate::ParseError;
+use crate::{ParseError, SerializeError};
 
 /// Maximum reasonable size for collections to prevent DoS attacks.
 const MAX_COLLECTION_SIZE: usize = 10_000_000;
@@ -295,7 +295,38 @@ mod codec_impl;
 #[cfg(feature = "codec")]
 pub use codec_impl::Codec;
 
-/// Serialize a RESP2 frame to bytes.
+/// Serialize a RESP2 frame to bytes, without validating it.
+///
+/// # Warning
+///
+/// This does not check that `frame` can be represented on the wire, and some
+/// frames cannot. A [`Frame::SimpleString`] or [`Frame::Error`] whose payload
+/// contains a CRLF terminates early here, and the remainder is read by the peer
+/// as further frames.
+///
+/// That is a protocol injection vector wherever untrusted bytes reach a
+/// payload, which is exactly what a server does when it reflects a command name
+/// into an error reply:
+///
+/// ```
+/// use bytes::Bytes;
+/// use resp_rs::resp2::{self, Frame};
+///
+/// let hostile = "BAD'\r\n+OK\r\n:9999";
+/// let reply = Frame::Error(Bytes::from(format!("ERR unknown command '{hostile}")));
+///
+/// // One frame in, three frames out.
+/// let wire = resp2::frame_to_bytes(&reply);
+/// let (_, rest) = resp2::parse_frame(wire).unwrap();
+/// assert!(!rest.is_empty());
+///
+/// // The checked path refuses it.
+/// assert!(resp2::try_frame_to_bytes(&reply).is_err());
+/// ```
+///
+/// Prefer [`try_frame_to_bytes`] for anything derived from input you do not
+/// control. The `Codec` encode path (behind the `codec` feature) already uses
+/// the checked path.
 ///
 /// # Examples
 ///
@@ -310,6 +341,96 @@ pub fn frame_to_bytes(frame: &Frame) -> Bytes {
     let mut buf = BytesMut::new();
     serialize_frame(frame, &mut buf);
     buf.freeze()
+}
+
+/// Serialize a RESP2 frame to bytes, rejecting frames the wire cannot carry.
+///
+/// Succeeds exactly when the result parses back to an identical frame with
+/// nothing left over:
+///
+/// ```text
+/// try_frame_to_bytes(f).is_ok()  <=>  parse_frame(frame_to_bytes(&f)) == Ok((f, empty))
+/// ```
+///
+/// The rules mirror the parser's acceptance grammar rather than being a
+/// separate list, so tightening a parse arm cannot silently open a gap here.
+///
+/// # Scope
+///
+/// Grammar validity only. The parse-side resource limits ([`MAX_DEPTH`],
+/// [`MAX_LINE_LENGTH`], and the collection and bulk size caps) also stop a
+/// frame from parsing back, but they bound what a peer may send rather than
+/// what a `Frame` may represent, so they are deliberately not checked here.
+///
+/// # Examples
+///
+/// ```
+/// use bytes::Bytes;
+/// use resp_rs::{SerializeError, resp2::{self, Frame}};
+///
+/// let ok = Frame::SimpleString(Bytes::from("OK"));
+/// assert_eq!(resp2::try_frame_to_bytes(&ok).unwrap(), Bytes::from("+OK\r\n"));
+///
+/// // A bare CR is payload and round-trips.
+/// let cr = Frame::SimpleString(Bytes::from(&b"a\rb"[..]));
+/// assert!(resp2::try_frame_to_bytes(&cr).is_ok());
+///
+/// // A CRLF would split the frame.
+/// let split = Frame::SimpleString(Bytes::from(&b"a\r\nb"[..]));
+/// assert_eq!(
+///     resp2::try_frame_to_bytes(&split),
+///     Err(SerializeError::LineContainsCrlf)
+/// );
+/// ```
+pub fn try_frame_to_bytes(frame: &Frame) -> Result<Bytes, SerializeError> {
+    let mut buf = BytesMut::new();
+    try_serialize_frame(frame, &mut buf)?;
+    Ok(buf.freeze())
+}
+
+/// Reject a line payload that would terminate its own frame.
+///
+/// A bare `\r` is fine: [`find_crlf`] scans for the pair, so a lone `\r` is
+/// ordinary payload and round-trips.
+#[inline]
+fn check_line_payload(payload: &[u8]) -> Result<(), SerializeError> {
+    if payload.windows(2).any(|w| w == b"\r\n") {
+        return Err(SerializeError::LineContainsCrlf);
+    }
+    Ok(())
+}
+
+/// Validating counterpart of [`serialize_frame`]. Validation happens inline
+/// during the walk so the checked path stays single-pass.
+fn try_serialize_frame(frame: &Frame, buf: &mut BytesMut) -> Result<(), SerializeError> {
+    match frame {
+        Frame::SimpleString(s) => {
+            check_line_payload(s)?;
+            buf.put_u8(b'+');
+            buf.extend_from_slice(s);
+            buf.extend_from_slice(b"\r\n");
+        }
+        Frame::Error(e) => {
+            check_line_payload(e)?;
+            buf.put_u8(b'-');
+            buf.extend_from_slice(e);
+            buf.extend_from_slice(b"\r\n");
+        }
+        // Integers are written from i64, and bulk strings are length-prefixed
+        // and read back by length, so neither can misrepresent itself.
+        Frame::Integer(_) | Frame::BulkString(_) => serialize_frame(frame, buf),
+        Frame::Array(Some(items)) => {
+            buf.put_u8(b'*');
+            let len = items.len().to_string();
+            buf.extend_from_slice(len.as_bytes());
+            buf.extend_from_slice(b"\r\n");
+            for item in items {
+                try_serialize_frame(item, buf)?;
+            }
+        }
+        Frame::Array(None) => serialize_frame(frame, buf),
+    }
+    Ok(())
 }
 
 fn serialize_frame(frame: &Frame, buf: &mut BytesMut) {

--- a/src/resp2_codec.rs
+++ b/src/resp2_codec.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
 use crate::codec::CodecError;
-use crate::resp2::{Frame, MAX_DEPTH, frame_to_bytes, parse_frame_inner};
+use crate::resp2::{Frame, MAX_DEPTH, parse_frame_inner, try_frame_to_bytes};
 
 /// A Tokio codec for RESP2 frames.
 ///
@@ -75,7 +75,10 @@ impl Encoder<Frame> for Codec {
     type Error = CodecError;
 
     fn encode(&mut self, item: Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let bytes = frame_to_bytes(&item);
+        // Checked: a frame that cannot parse back as itself is refused rather
+        // than written to the socket. This is the point where a server emits,
+        // so it is where the CRLF injection path is closed.
+        let bytes = try_frame_to_bytes(&item)?;
         dst.extend_from_slice(&bytes);
         Ok(())
     }
@@ -143,6 +146,28 @@ mod tests {
             result,
             Err(CodecError::Parse(ParseError::InvalidTag(b'X')))
         ));
+    }
+
+    #[test]
+    fn encode_refuses_a_frame_that_would_split_the_stream() {
+        // A server reflecting untrusted input into an error reply is the
+        // realistic injection path. encode must refuse rather than emit.
+        let hostile = "BAD'\r\n+OK\r\n:9999";
+        let reply = Frame::Error(Bytes::from(format!("ERR unknown command '{hostile}")));
+
+        let mut codec = Codec::new();
+        let mut buf = BytesMut::new();
+        let result = codec.encode(reply, &mut buf);
+
+        assert!(
+            matches!(result, Err(CodecError::Serialize(_))),
+            "got {result:?}"
+        );
+        assert!(
+            buf.is_empty(),
+            "refused frame still wrote {} bytes",
+            buf.len()
+        );
     }
 
     #[test]

--- a/src/resp3.rs
+++ b/src/resp3.rs
@@ -456,7 +456,7 @@ impl Frame {
     }
 }
 
-pub use crate::ParseError;
+pub use crate::{ParseError, SerializeError};
 
 /// Parse a single RESP3 frame from the provided `Bytes`.
 ///
@@ -1235,13 +1235,198 @@ fn parse_count(buf: &[u8]) -> Result<usize, ParseError> {
     Ok(count)
 }
 
-/// Converts a Frame to its RESP3 byte representation.
+/// Converts a Frame to its RESP3 byte representation, without validating it.
 ///
-/// This function serializes a Frame into the corresponding RESP3 protocol bytes.
+/// # Warning
+///
+/// This does not check that `frame` can be represented on the wire, and several
+/// frames cannot. A line payload containing CRLF splits the frame, letting the
+/// remainder be read as further frames, which is a protocol injection vector
+/// wherever untrusted bytes reach a payload. Others change type or are rejected
+/// outright: see [`try_frame_to_bytes`] for the full set.
+///
+/// Prefer [`try_frame_to_bytes`] for anything derived from input you do not
+/// control. The `Codec` encode path (behind the `codec` feature) already uses
+/// the checked path.
 pub fn frame_to_bytes(frame: &Frame) -> Bytes {
     let mut buf = BytesMut::new();
     serialize_frame(frame, &mut buf);
     buf.freeze()
+}
+
+/// Serialize a RESP3 frame to bytes, rejecting frames the wire cannot carry.
+///
+/// Succeeds exactly when the result parses back to an identical frame with
+/// nothing left over:
+///
+/// ```text
+/// try_frame_to_bytes(f).is_ok()  <=>  parse_frame(frame_to_bytes(&f)) == Ok((f, empty))
+/// ```
+///
+/// The rules mirror the parser's acceptance grammar rather than being a
+/// separate list, so tightening a parse arm cannot silently open a gap here.
+/// What that catches, beyond the CRLF case:
+///
+/// | Frame | Unchecked wire | Comes back as |
+/// | --- | --- | --- |
+/// | `BigNumber(b"abc")` | `(abc\r\n` | rejected |
+/// | `SpecialFloat(b"1.5")` | `,1.5\r\n` | `Double(1.5)` |
+/// | `Double(f64::NAN)` | `,NaN\r\n` | `SpecialFloat(b"nan")` |
+/// | `VerbatimString(b"text", _)` | `=6\r\ntext:x\r\n` | rejected |
+/// | `StreamedString` with an empty chunk | mid-stream `;0\r\n` | truncated |
+/// | `Attribute` inside an aggregate | slot skipped | one element short |
+///
+/// # Scope
+///
+/// Grammar validity only. The parse-side resource limits ([`MAX_DEPTH`],
+/// [`MAX_LINE_LENGTH`], and the collection and bulk size caps) also stop a
+/// frame from parsing back, but they bound what a peer may send rather than
+/// what a `Frame` may represent, so they are deliberately not checked here.
+///
+/// # Examples
+///
+/// ```
+/// use bytes::Bytes;
+/// use resp_rs::{SerializeError, resp3::{self, Frame}};
+///
+/// assert!(resp3::try_frame_to_bytes(&Frame::Double(1.5)).is_ok());
+/// assert_eq!(
+///     resp3::try_frame_to_bytes(&Frame::Double(f64::NAN)),
+///     Err(SerializeError::NonFiniteDouble)
+/// );
+/// ```
+pub fn try_frame_to_bytes(frame: &Frame) -> Result<Bytes, SerializeError> {
+    let mut buf = BytesMut::new();
+    try_serialize_frame(frame, &mut buf)?;
+    Ok(buf.freeze())
+}
+
+/// Reject a line payload that would terminate its own frame.
+///
+/// A bare `\r` is fine: [`find_crlf`] scans for the pair, so a lone `\r` is
+/// ordinary payload and round-trips.
+#[inline]
+fn check_line_payload(payload: &[u8]) -> Result<(), SerializeError> {
+    if payload.windows(2).any(|w| w == b"\r\n") {
+        return Err(SerializeError::LineContainsCrlf);
+    }
+    Ok(())
+}
+
+/// Serialize one aggregate element. An attribute cannot occupy a slot, because
+/// the parser skips it there and the aggregate would come back short.
+#[inline]
+fn try_serialize_element(frame: &Frame, buf: &mut BytesMut) -> Result<(), SerializeError> {
+    if matches!(frame, Frame::Attribute(_)) {
+        return Err(SerializeError::AttributeInAggregate);
+    }
+    try_serialize_frame(frame, buf)
+}
+
+/// Validating counterpart of [`serialize_frame`]. Validation happens inline
+/// during the walk so the checked path stays single-pass.
+fn try_serialize_frame(frame: &Frame, buf: &mut BytesMut) -> Result<(), SerializeError> {
+    match frame {
+        Frame::SimpleString(s) => {
+            check_line_payload(s)?;
+            serialize_frame(frame, buf);
+        }
+        Frame::Error(e) => {
+            check_line_payload(e)?;
+            serialize_frame(frame, buf);
+        }
+        Frame::BigNumber(n) => {
+            // parse_frame_inner checks the same grammar via check_big_number.
+            let digits = match n.first() {
+                Some(b'+') | Some(b'-') => &n[1..],
+                _ => &n[..],
+            };
+            if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+                return Err(SerializeError::InvalidBigNumber);
+            }
+            serialize_frame(frame, buf);
+        }
+        Frame::SpecialFloat(f) => {
+            // parse_double_frame yields SpecialFloat for exactly these three
+            // and normalizes anything else into a Double.
+            if !matches!(f.as_ref(), b"inf" | b"-inf" | b"nan") {
+                return Err(SerializeError::InvalidSpecialFloat);
+            }
+            serialize_frame(frame, buf);
+        }
+        Frame::Double(d) => {
+            // f64::to_string emits "NaN" and "inf" for non-finite values, which
+            // the parser reads back as a SpecialFloat, changing the type.
+            if !d.is_finite() {
+                return Err(SerializeError::NonFiniteDouble);
+            }
+            serialize_frame(frame, buf);
+        }
+        Frame::VerbatimString(format, _) => {
+            // parse_verbatim requires the separator at index 3 exactly.
+            if format.len() != 3 || format.contains(&b':') {
+                return Err(SerializeError::InvalidVerbatimFormat);
+            }
+            serialize_frame(frame, buf);
+        }
+        Frame::StreamedString(chunks) => {
+            // An empty chunk is the end-of-stream marker, so one in the middle
+            // truncates the stream in place.
+            if chunks.iter().any(|c| c.is_empty()) {
+                return Err(SerializeError::EmptyStreamedChunk);
+            }
+            serialize_frame(frame, buf);
+        }
+        Frame::Array(Some(items)) => {
+            buf.put_u8(b'*');
+            write_len(items.len(), buf);
+            for item in items {
+                try_serialize_element(item, buf)?;
+            }
+        }
+        Frame::Set(items) => {
+            buf.put_u8(b'~');
+            write_len(items.len(), buf);
+            for item in items {
+                try_serialize_element(item, buf)?;
+            }
+        }
+        Frame::Push(items) => {
+            buf.put_u8(b'>');
+            write_len(items.len(), buf);
+            for item in items {
+                try_serialize_element(item, buf)?;
+            }
+        }
+        Frame::Map(pairs) => {
+            buf.put_u8(b'%');
+            write_len(pairs.len(), buf);
+            for (k, v) in pairs {
+                try_serialize_element(k, buf)?;
+                try_serialize_element(v, buf)?;
+            }
+        }
+        Frame::Attribute(pairs) => {
+            buf.put_u8(b'|');
+            write_len(pairs.len(), buf);
+            for (k, v) in pairs {
+                try_serialize_element(k, buf)?;
+                try_serialize_element(v, buf)?;
+            }
+        }
+        // Everything else is either length-prefixed, written from a typed
+        // value, or a fixed token, so it cannot misrepresent itself.
+        other => serialize_frame(other, buf),
+    }
+    Ok(())
+}
+
+/// Write a decimal count followed by CRLF.
+#[inline]
+fn write_len(n: usize, buf: &mut BytesMut) {
+    let len = n.to_string();
+    buf.extend_from_slice(len.as_bytes());
+    buf.extend_from_slice(b"\r\n");
 }
 
 fn serialize_frame(frame: &Frame, buf: &mut BytesMut) {

--- a/src/resp3_codec.rs
+++ b/src/resp3_codec.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
 use crate::codec::CodecError;
-use crate::resp3::{Frame, MAX_DEPTH, frame_to_bytes, parse_frame_inner};
+use crate::resp3::{Frame, MAX_DEPTH, parse_frame_inner, try_frame_to_bytes};
 
 /// A Tokio codec for RESP3 frames.
 ///
@@ -76,7 +76,10 @@ impl Encoder<Frame> for Codec {
     type Error = CodecError;
 
     fn encode(&mut self, item: Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let bytes = frame_to_bytes(&item);
+        // Checked: a frame that cannot parse back as itself is refused rather
+        // than written to the socket. This is the point where a server emits,
+        // so it is where the CRLF injection path is closed.
+        let bytes = try_frame_to_bytes(&item)?;
         dst.extend_from_slice(&bytes);
         Ok(())
     }
@@ -162,6 +165,41 @@ mod tests {
             codec.decode(&mut buf),
             Err(CodecError::Parse(ParseError::InvalidTag(b'X')))
         ));
+    }
+
+    #[test]
+    fn encode_refuses_a_frame_that_would_split_the_stream() {
+        // A server reflecting untrusted input into an error reply is the
+        // realistic injection path. encode must refuse rather than emit.
+        let hostile = "BAD'\r\n+OK\r\n:9999";
+        let reply = Frame::Error(Bytes::from(format!("ERR unknown command '{hostile}")));
+
+        let mut codec = Codec::new();
+        let mut buf = BytesMut::new();
+        let result = codec.encode(reply, &mut buf);
+
+        assert!(
+            matches!(result, Err(CodecError::Serialize(_))),
+            "got {result:?}"
+        );
+        assert!(
+            buf.is_empty(),
+            "refused frame still wrote {} bytes",
+            buf.len()
+        );
+    }
+
+    #[test]
+    fn encode_refuses_a_non_finite_double() {
+        // Would come back as SpecialFloat, silently changing type.
+        let mut codec = Codec::new();
+        let mut buf = BytesMut::new();
+        let result = codec.encode(Frame::Double(f64::NAN), &mut buf);
+        assert!(
+            matches!(result, Err(CodecError::Serialize(_))),
+            "got {result:?}"
+        );
+        assert!(buf.is_empty());
     }
 
     #[test]

--- a/tests/property.proptest-regressions
+++ b/tests/property.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc efe3f1bd50d24e4386c6ccfde9db9d1187aadb3157483db6bd9958a14f30e85f # shrinks to frame = BigNumber(b"abc")
+cc 546c43167b03d48c5c02ba722846d75cdf32c3bb020796f7f8a3f309c4b6d05f # shrinks to frame = Push([Map([(SimpleString(b""), SimpleString(b"\r"))])])

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -613,3 +613,124 @@ proptest! {
         prop_assert_eq!(safe_rest, unsafe_rest);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Checked serialization (issue #60)
+// ---------------------------------------------------------------------------
+
+/// Generate frames that are deliberately NOT representable on the wire, one per
+/// rule, so the property is exercised from both sides.
+fn arb_invalid_resp3_frame() -> impl Strategy<Value = resp_rs::resp3::Frame> {
+    use resp_rs::resp3::Frame;
+    prop_oneof![
+        // CRLF inside a line payload splits the frame.
+        Just(Frame::SimpleString(Bytes::from(&b"a\r\nb"[..]))),
+        Just(Frame::Error(Bytes::from(&b"ERR x\r\n+OK"[..]))),
+        // Big numbers are digit-strict since #67.
+        Just(Frame::BigNumber(Bytes::from(&b"abc"[..]))),
+        Just(Frame::BigNumber(Bytes::new())),
+        Just(Frame::BigNumber(Bytes::from(&b"1.5"[..]))),
+        // SpecialFloat is exactly these three spellings; anything else
+        // normalizes to a Double on the way back.
+        Just(Frame::SpecialFloat(Bytes::from(&b"1.5"[..]))),
+        Just(Frame::SpecialFloat(Bytes::from(&b"INF"[..]))),
+        // Non-finite doubles come back as SpecialFloat, changing type.
+        Just(Frame::Double(f64::NAN)),
+        Just(Frame::Double(f64::INFINITY)),
+        Just(Frame::Double(f64::NEG_INFINITY)),
+        // The parser requires the verbatim separator at index 3 exactly.
+        Just(Frame::VerbatimString(
+            Bytes::from(&b"text"[..]),
+            Bytes::from(&b"x"[..])
+        )),
+        Just(Frame::VerbatimString(
+            Bytes::from(&b"ab"[..]),
+            Bytes::from(&b"x"[..])
+        )),
+        Just(Frame::VerbatimString(Bytes::new(), Bytes::from(&b"x"[..]))),
+        Just(Frame::VerbatimString(
+            Bytes::from(&b"a:b"[..]),
+            Bytes::from(&b"x"[..])
+        )),
+        // An empty chunk is the end-of-stream marker.
+        Just(Frame::StreamedString(vec![
+            Bytes::from(&b"a"[..]),
+            Bytes::new(),
+            Bytes::from(&b"b"[..]),
+        ])),
+        // An attribute does not occupy an element slot (#59).
+        Just(Frame::Array(Some(vec![Frame::Attribute(vec![])]))),
+        Just(Frame::Set(vec![Frame::Attribute(vec![])])),
+        Just(Frame::Map(vec![(
+            Frame::Attribute(vec![]),
+            Frame::Integer(1)
+        )])),
+    ]
+}
+
+proptest! {
+    /// The specification: checked serialization succeeds exactly when the bytes
+    /// parse back to an identical frame with nothing left over.
+    ///
+    /// Stated as an iff so it cannot go stale the way a rule list does. A parse
+    /// arm tightening without a matching serializer rule breaks this
+    /// immediately, which is how #67 opened the BigNumber gap unnoticed.
+    #[test]
+    fn resp3_checked_serialization_iff_roundtrip(frame in arb_resp3_frame()) {
+        let round_trips = match resp_rs::resp3::parse_frame(
+            resp_rs::resp3::frame_to_bytes(&frame),
+        ) {
+            Ok((parsed, rest)) => parsed == frame && rest.is_empty(),
+            Err(_) => false,
+        };
+        prop_assert_eq!(
+            resp_rs::resp3::try_frame_to_bytes(&frame).is_ok(),
+            round_trips,
+            "checked serialization disagreed with round trip for {:?}",
+            frame
+        );
+    }
+
+    #[test]
+    fn resp2_checked_serialization_iff_roundtrip(frame in arb_resp2_frame()) {
+        let round_trips = match resp_rs::resp2::parse_frame(
+            resp_rs::resp2::frame_to_bytes(&frame),
+        ) {
+            Ok((parsed, rest)) => parsed == frame && rest.is_empty(),
+            Err(_) => false,
+        };
+        prop_assert_eq!(
+            resp_rs::resp2::try_frame_to_bytes(&frame).is_ok(),
+            round_trips,
+            "checked serialization disagreed with round trip for {:?}",
+            frame
+        );
+    }
+
+    /// Same property from the other side: every frame that is deliberately
+    /// unrepresentable must be refused, and must genuinely fail to round trip.
+    #[test]
+    fn resp3_invalid_frames_are_refused(frame in arb_invalid_resp3_frame()) {
+        let round_trips = match resp_rs::resp3::parse_frame(
+            resp_rs::resp3::frame_to_bytes(&frame),
+        ) {
+            Ok((parsed, rest)) => parsed == frame && rest.is_empty(),
+            Err(_) => false,
+        };
+        prop_assert!(!round_trips, "expected {:?} not to round trip", frame);
+        prop_assert!(
+            resp_rs::resp3::try_frame_to_bytes(&frame).is_err(),
+            "expected {:?} to be refused",
+            frame
+        );
+    }
+
+    /// A checked serialization that succeeds must produce exactly the same
+    /// bytes as the unchecked one, so the two paths cannot drift.
+    #[test]
+    fn resp3_checked_and_unchecked_agree_when_valid(frame in arb_resp3_frame()) {
+        if let Ok(checked) = resp_rs::resp3::try_frame_to_bytes(&frame) {
+            prop_assert_eq!(checked, resp_rs::resp3::frame_to_bytes(&frame));
+        }
+    }
+}


### PR DESCRIPTION
Closes #60

## Problem

`frame_to_bytes` copies payloads onto the wire without validating them, so `Frame` values exist that serialize to bytes the crate's own parser rejects or reads back as something else. The worst case is not a round-trip wart: a CRLF inside an `Error` payload splits one frame into three, and a server reflecting untrusted input into `ERR unknown command '<X>'` hands the attacker control of the reply stream.

```
server intended ONE error frame:
"-ERR unknown command 'BADCMD'\r\n+OK\r\n:9999\r\n"

client reads:
  frame 0: Error("ERR unknown command 'BADCMD'")
  frame 1: SimpleString("OK")     <- attacker-authored
  frame 2: Integer(9999)          <- attacker-authored
```

## Implemented to the property, not to a rule list

The invariant is `try_frame_to_bytes(f)` succeeds exactly when `parse_frame(frame_to_bytes(f))` is `(f, empty)`.

A fixed rule list goes stale the moment a parse arm tightens, and that has already happened twice in this repo. #67 made big-number parsing digit-strict, which broke `BigNumber(b"abc")` round-tripping and created a case the issue's own CRLF-based rules do not catch. #59 made attributes non-elements, so `Frame::Attribute` inside an aggregate is no longer a structure the parser can produce.

Verified failing cases at HEAD, all of which the property covers:

| Frame | Wire | Comes back as |
| --- | --- | --- |
| `Error` containing CRLF | splits | three frames |
| `VerbatimString(b"text", ...)` | `=6\r\ntext:x\r\n` | `Err(InvalidFormat)` |
| `BigNumber(b"abc")` | `(abc\r\n` | `Err(InvalidFormat)` |
| `SpecialFloat(b"1.5")` | `,1.5\r\n` | `Double(1.5)` |
| `Double(f64::NAN)` | `,NaN\r\n` | `SpecialFloat(b"nan")` |
| `Double(f64::INFINITY)` | `,inf\r\n` | `SpecialFloat(b"inf")` |
| `StreamedString` with an empty chunk | mid-stream `;0\r\n` | truncated |
| `Attribute` inside an aggregate | slot skipped | element count short |

Per-variant rules mirror the parser's acceptance grammar rather than being invented: no CRLF *sequence* in line frames (a bare `\r` is legal and round-trips, per #65), `[+-]?digits` for `BigNumber`, exactly `inf`/`-inf`/`nan` for `SpecialFloat`, finite-only for `Double`, a 3-byte colon-free tag for `VerbatimString`, non-empty chunks in `StreamedString`, and no `Attribute` in an element position.

## Shape

- `try_frame_to_bytes(&Frame) -> Result<Bytes, SerializeError>` in both protocols, validating inline during a single fallible walk rather than in a separate pass.
- `frame_to_bytes` keeps its signature and gains a documented precondition plus an explicit warning about the injection path. Non-breaking.
- `Encoder::encode` uses the checked path, so the check sits where a server actually writes to a socket. `CodecError` gains a `Serialize` variant and `#[non_exhaustive]`.

## Scope

Grammar validity only. The parse-side resource limits (`MAX_DEPTH`, `MAX_LINE_LENGTH`, `MAX_COLLECTION_SIZE`, `MAX_BULK_STRING_SIZE`) also break round trips, but they are about what a peer may send rather than what a `Frame` may represent, and folding them in would make the contract hard to state. The property test's generators stay bounded under them and the docs say so.

## Tests

The iff-property in both protocols over the existing arbitrary-frame generators, plus a generator of deliberately invalid frames covering every rule, plus each table row above as an explicit case, plus a codec test asserting `encode` refuses the injection payload.