### PR TITLE
test: add differential and unchecked fuzz targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -24,6 +24,8 @@ jobs:
           - fuzz_resp2_streaming
           - fuzz_resp3_streaming
           - fuzz_nesting
+          - fuzz_resp2_differential
+          - fuzz_unchecked
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -15,6 +15,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +41,24 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -77,6 +105,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,8 +157,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "redis-protocol"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdba59219406899220fc4cdfd17a95191ba9c9afb719b5fa5a083d63109a9f1"
+dependencies = [
+ "bytes",
+ "bytes-utils",
+ "cookie-factory",
+ "crc16",
+ "log",
+ "nom",
+]
+
+[[package]]
 name = "resp-rs"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "thiserror",
@@ -114,6 +184,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "libfuzzer-sys",
+ "redis-protocol",
  "resp-rs",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,9 +13,14 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 bytes = "1"
+# An oracle the crate cannot agree with by being consistently wrong.
+redis-protocol = { version = "6", features = ["resp2", "resp3", "bytes"] }
 
 [dependencies.resp-rs]
 path = ".."
+# Without this, parse_frame_unchecked is not compiled into any fuzz binary, so
+# the safe-versus-unchecked axis was unreachable from fuzzing.
+features = ["unsafe-internals"]
 
 [[bin]]
 name = "fuzz_resp2_parse"
@@ -83,6 +88,20 @@ bench = false
 [[bin]]
 name = "fuzz_nesting"
 path = "fuzz_targets/fuzz_nesting.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_resp2_differential"
+path = "fuzz_targets/fuzz_resp2_differential.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_unchecked"
+path = "fuzz_targets/fuzz_unchecked.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/fuzz_resp2_differential.rs
+++ b/fuzz/fuzz_targets/fuzz_resp2_differential.rs
@@ -1,0 +1,189 @@
+#![no_main]
+use bytes::Bytes;
+use libfuzzer_sys::fuzz_target;
+use redis_protocol::resp2::types::OwnedFrame as TheirFrame;
+use resp_rs::{ParseError, resp2};
+
+// Every other oracle in this crate compares the crate against itself: roundtrip
+// against its own serializer, direct parse against its own Parser, safe against
+// its own unchecked path. All of those are closed under a consistent mistake. A
+// parser and serializer that are wrong in the same direction are a fixed point
+// of the roundtrip property, and no amount of runtime finds it.
+//
+// This target compares against redis-protocol, which was written by someone
+// else from the same spec. It cannot be talked into the same mistake.
+//
+// Measured motivation: seven already-fixed bugs were reverted one at a time and
+// the existing targets executed roughly 50 million inputs against them without
+// a single finding.
+
+/// A shape both crates can be mapped onto without losing anything that matters.
+///
+/// The two model frames differently, so comparing `Debug` output or either
+/// native type directly would report differences that are not defects.
+#[derive(Debug, PartialEq)]
+enum Norm {
+    Simple(Vec<u8>),
+    Error(Vec<u8>),
+    Int(i64),
+    Bulk(Vec<u8>),
+    /// Both null forms collapse here. resp-rs distinguishes `BulkString(None)`
+    /// from `Array(None)`; redis-protocol has a single `Null`. The distinction
+    /// is real but unobservable through this oracle, so it is not compared.
+    Null,
+    Array(Vec<Norm>),
+}
+
+fn norm_ours(f: &resp2::Frame) -> Norm {
+    match f {
+        resp2::Frame::SimpleString(b) => Norm::Simple(b.to_vec()),
+        resp2::Frame::Error(b) => Norm::Error(b.to_vec()),
+        resp2::Frame::Integer(i) => Norm::Int(*i),
+        resp2::Frame::BulkString(Some(b)) => Norm::Bulk(b.to_vec()),
+        resp2::Frame::BulkString(None) => Norm::Null,
+        resp2::Frame::Array(Some(v)) => Norm::Array(v.iter().map(norm_ours).collect()),
+        resp2::Frame::Array(None) => Norm::Null,
+    }
+}
+
+fn norm_theirs(f: &TheirFrame) -> Norm {
+    match f {
+        TheirFrame::SimpleString(v) => Norm::Simple(v.clone()),
+        TheirFrame::Error(s) => Norm::Error(s.as_bytes().to_vec()),
+        TheirFrame::Integer(i) => Norm::Int(*i),
+        TheirFrame::BulkString(v) => Norm::Bulk(v.clone()),
+        TheirFrame::Null => Norm::Null,
+        TheirFrame::Array(v) => Norm::Array(v.iter().map(norm_theirs).collect()),
+    }
+}
+
+/// Errors that mean "this crate imposes a limit the reference does not", rather
+/// than "these two disagree about the grammar".
+///
+/// Keeping this list short is the point. Anything not on it that diverges is a
+/// bug in one crate or the other.
+fn is_resource_limit(e: &ParseError) -> bool {
+    matches!(
+        e,
+        // MAX_DEPTH, MAX_LINE_LENGTH, MAX_COLLECTION_SIZE, MAX_BULK_STRING_SIZE.
+        ParseError::DepthExceeded | ParseError::LineTooLong | ParseError::BadLength
+    )
+}
+
+/// True when the reference's laxness about bulk strings could explain a
+/// divergence, so the divergence should not be blamed on this crate.
+///
+/// The target found this on its first run. redis-protocol does not verify the
+/// CRLF that terminates a bulk string body:
+///
+/// ```text
+/// $1\r\nX!!      ours=InvalidFormat  theirs=BulkString("X")   consumed=7
+/// $3\r\nabcZZ    ours=InvalidFormat  theirs=BulkString("abc") consumed=9
+/// $0\r\nZZ       ours=InvalidFormat  theirs=BulkString("")    consumed=6
+/// ```
+///
+/// The grammar is `$<length>\r\n<data>\r\n` with the trailing CRLF required, so
+/// this crate is right to reject and the reference is lax. Worth reporting
+/// upstream; it is not a defect here.
+///
+/// Detecting it exactly would mean re-serialising the reference's frame and
+/// comparing against the consumed prefix, which needs a reverse mapping whose
+/// null handling is ambiguous (`Null` is both `$-1` and `*-1`). Rather than
+/// hand-roll that and get it subtly wrong, this excludes any input carrying a
+/// bulk tag at all.
+///
+/// The cost is real and worth stating: divergences on inputs containing `$` are
+/// not checked in the we-reject-they-accept direction. Frames built only from
+/// `+` `-` `:` `*` are still checked, which is the direction that would have
+/// caught #49, where the reference reads `:+42\r\n` as 42 and this crate used
+/// to refuse the sign.
+fn bulk_laxness_may_apply(data: &[u8], consumed: usize) -> bool {
+    data[..consumed.min(data.len())].contains(&b'$')
+}
+
+/// redis-protocol types a simple error as `String`, so it rejects payloads this
+/// crate accepts as raw bytes. That permissiveness is deliberate and documented
+/// (issue #17), so a divergence is only excused when the bytes really are not
+/// UTF-8.
+fn ours_holds_non_utf8_error(f: &resp2::Frame) -> bool {
+    match f {
+        resp2::Frame::Error(b) => core::str::from_utf8(b).is_err(),
+        resp2::Frame::Array(Some(v)) => v.iter().any(ours_holds_non_utf8_error),
+        _ => false,
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let ours = resp2::parse_frame(Bytes::copy_from_slice(data));
+    let theirs = redis_protocol::resp2::decode::decode(data);
+
+    match (&ours, &theirs) {
+        (Ok((our_frame, rest)), Ok(Some((their_frame, their_consumed)))) => {
+            // Framing first. Disagreeing about how many bytes a frame occupies
+            // desynchronizes a connection, which is worse than disagreeing
+            // about the value: every later reply is attributed to the wrong
+            // command. This is the assertion that catches that class.
+            if !bulk_laxness_may_apply(data, *their_consumed) {
+                assert_eq!(
+                    data.len() - rest.len(),
+                    *their_consumed,
+                    "consumed lengths differ\n  input:  {data:?}\n  ours:   {our_frame:?}\n  theirs: {their_frame:?}"
+                );
+            }
+            assert_eq!(
+                norm_ours(our_frame),
+                norm_theirs(their_frame),
+                "decoded values differ\n  input: {data:?}"
+            );
+        }
+
+        // Both want more input.
+        (Err(ParseError::Incomplete), Ok(None)) => {}
+
+        // Both reject. Includes the case where we want more input and they
+        // reject outright, which is reachable because the two decide some
+        // malformed prefixes at different points in the buffer.
+        (Err(_), Err(_)) => {}
+
+        // They want more input, we rejected.
+        //
+        // Not asserted. `Ok(None)` is the reference declining to decide yet,
+        // not the reference disagreeing, so it cannot contradict our verdict.
+        // The same bulk-terminator laxness described above surfaces here as
+        // well: for `*11\r\n$0\r\n\r\r` this crate says InvalidFormat, which is
+        // correct because a `\r\r` terminator can never become valid, while the
+        // reference asks for more bytes. There is no `consumed` to check the
+        // way there is in the `Ok(Some)` arm.
+        //
+        // What this gives up is catching a hard error returned on a genuinely
+        // valid prefix, which would break streaming. The `fuzz_resp2_streaming`
+        // target already covers that from the other direction, by requiring a
+        // chunked feed to agree with a whole-buffer parse.
+        (Err(_), Ok(None)) => {}
+
+        // We accept, they reject. Only acceptable for the documented raw-bytes
+        // permissiveness in errors.
+        (Ok((our_frame, _)), Err(_)) => {
+            assert!(
+                ours_holds_non_utf8_error(our_frame),
+                "we accept what the reference rejects\n  input: {data:?}\n  ours:  {our_frame:?}"
+            );
+        }
+
+        // We reject, they accept. This is the over-strictness direction, and it
+        // is exactly how issue #49 would have been caught: the reference reads
+        // `:+42\r\n` as 42 while this crate used to refuse the sign.
+        (Err(e), Ok(Some((their_frame, their_consumed)))) => {
+            assert!(
+                is_resource_limit(e) || bulk_laxness_may_apply(data, *their_consumed),
+                "we reject what the reference accepts\n  input:  {data:?}\n  ours:   {e:?}\n  theirs: {their_frame:?}"
+            );
+        }
+
+        // We accept, they want more. Would mean we framed a shorter prefix than
+        // the reference thinks is complete.
+        (Ok((our_frame, _)), Ok(None)) => {
+            panic!("we accept a frame the reference considers incomplete\n  input: {data:?}\n  ours:  {our_frame:?}");
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_unchecked.rs
+++ b/fuzz/fuzz_targets/fuzz_unchecked.rs
@@ -1,0 +1,53 @@
+#![no_main]
+use bytes::Bytes;
+use libfuzzer_sys::fuzz_target;
+use resp_rs::{resp2, resp3};
+
+// Safe versus unchecked is the one oracle axis in this crate empirically proven
+// to find a real bug: issue #65, where `find_cr` stopped at a bare CR while
+// `find_crlf` required the pair, so the unchecked path desynchronized on input
+// the safe path had already validated.
+//
+// It was found by proptest, not here, because `fuzz/Cargo.toml` declared
+// `resp-rs` with no `features` key, so `parse_frame_unchecked` was not compiled
+// into any fuzz binary at all. The axis existed and was unreachable.
+//
+// The unchecked parsers are only defined on input the safe parser accepts, so
+// every case is gated on a successful safe parse first. Feeding them anything
+// else is undefined behavior, not a finding.
+
+fuzz_target!(|input: &[u8]| {
+    // First byte selects the protocol, the rest is the frame. Same shape as
+    // fuzz_nesting, and it avoids pulling in arbitrary's derive feature.
+    let Some((selector, data)) = input.split_first() else {
+        return;
+    };
+    let bytes = Bytes::copy_from_slice(data);
+
+    match selector % 2 {
+        0 => {
+            // The safe parse is the precondition, and its `rest` matters as
+            // much as its frame: #65 was a disagreement about where the frame
+            // ended, not about what it contained.
+            let Ok((safe_frame, safe_rest)) = resp2::parse_frame(bytes.clone()) else {
+                return;
+            };
+            // SAFETY: parse_frame just accepted this buffer, which is exactly
+            // the contract parse_frame_unchecked documents.
+            let (unchecked_frame, unchecked_rest) =
+                unsafe { resp2::parse_frame_unchecked(bytes) };
+            assert_eq!(safe_frame, unchecked_frame, "frames differ: {data:?}");
+            assert_eq!(safe_rest, unchecked_rest, "consumed lengths differ: {data:?}");
+        }
+        _ => {
+            let Ok((safe_frame, safe_rest)) = resp3::parse_frame(bytes.clone()) else {
+                return;
+            };
+            // SAFETY: as above.
+            let (unchecked_frame, unchecked_rest) =
+                unsafe { resp3::parse_frame_unchecked(bytes) };
+            assert_eq!(safe_frame, unchecked_frame, "frames differ: {data:?}");
+            assert_eq!(safe_rest, unchecked_rest, "consumed lengths differ: {data:?}");
+        }
+    }
+});

--- a/src/resp2_unchecked.rs
+++ b/src/resp2_unchecked.rs
@@ -41,13 +41,17 @@ unsafe fn find_cr(buf: &[u8], from: usize) -> usize {
 ///
 /// # Safety
 ///
-/// Caller must ensure `buf` contains only ASCII digits (optionally preceded
-/// by `-`) and is non-empty.
+/// Caller must ensure `buf` contains only ASCII digits, optionally preceded
+/// by `+` or `-`, and is non-empty.
 #[inline(always)]
 unsafe fn parse_i64_unchecked(buf: &[u8]) -> i64 {
     let mut i = 0;
-    let neg = *buf.get_unchecked(0) == b'-';
-    if neg {
+    // Both signs, mirroring the safe parser. Missing `+` here does not merely
+    // reject: the byte stays in the digit run and `b'+' - b'0'` wraps, so
+    // `:+0\r\n` decoded as 2510 (issue #77).
+    let first = *buf.get_unchecked(0);
+    let neg = first == b'-';
+    if neg || first == b'+' {
         i = 1;
     }
     let mut v: i64 = 0;
@@ -204,6 +208,13 @@ mod tests {
             "-a\rb\r\n",
             "*2\r\n+a\rZ+b\r\n+x\r\n",
             "*2\r\n+a\rb\r\n+x\r\n",
+            // An explicit plus sign. The safe parser accepted these from #56
+            // while this one still stripped only `-`, leaving `+` in the digit
+            // run where `b'+' - b'0'` wrapped: `:+0\r\n` decoded as 2510
+            // (issue #77).
+            ":+0\r\n",
+            ":+42\r\n",
+            "*2\r\n:+1\r\n:-1\r\n",
         ];
 
         for wire in cases {

--- a/src/resp3_unchecked.rs
+++ b/src/resp3_unchecked.rs
@@ -46,8 +46,12 @@ unsafe fn parse_usize_unchecked(buf: &[u8]) -> usize {
 #[inline(always)]
 unsafe fn parse_i64_unchecked(buf: &[u8]) -> i64 {
     let mut i = 0;
-    let neg = *buf.get_unchecked(0) == b'-';
-    if neg {
+    // Both signs, mirroring the safe parser. Missing `+` here does not merely
+    // reject: the byte stays in the digit run and `b'+' - b'0'` wraps, so
+    // `:+0\r\n` decoded as 2510 (issue #77).
+    let first = *buf.get_unchecked(0);
+    let neg = first == b'-';
+    if neg || first == b'+' {
         i = 1;
     }
     let mut v: i64 = 0;
@@ -124,6 +128,20 @@ unsafe fn parse_inner(input: &Bytes, pos: usize) -> (Frame, usize) {
             }
             let s = core::str::from_utf8_unchecked(line);
             let v: f64 = s.parse().unwrap_unchecked();
+            // The safe parser canonicalizes any non-finite value to a
+            // SpecialFloat, so spellings the exact-match above misses, such as
+            // `Inf` or `NaN`, still land there. Without this, `,Inf\r\n` gave
+            // SpecialFloat("inf") safely and Double(inf) here.
+            if v.is_infinite() || v.is_nan() {
+                let canonical = if v.is_nan() {
+                    "nan"
+                } else if v.is_sign_negative() {
+                    "-inf"
+                } else {
+                    "inf"
+                };
+                return (Frame::SpecialFloat(Bytes::from(canonical)), cr + 2);
+            }
             (Frame::Double(v), cr + 2)
         }
         b'#' => {
@@ -310,6 +328,20 @@ mod tests {
             "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
             "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n",
             "~2\r\n+a\r\n+b\r\n",
+            // An explicit plus sign. The safe parser accepted these from #56
+            // while this one still stripped only `-`, leaving `+` in the digit
+            // run where `b'+' - b'0'` wrapped: `:+0\r\n` decoded as 2510
+            // (issue #77).
+            ":+0\r\n",
+            ":+42\r\n",
+            "*2\r\n:+1\r\n:-1\r\n",
+            // Non-canonical spellings of the special floats. The safe parser
+            // canonicalizes any non-finite value to a SpecialFloat, so these
+            // must not come back as Double here.
+            ",Inf\r\n",
+            ",NaN\r\n",
+            ",-Inf\r\n",
+            ",infinity\r\n",
             "%1\r\n+key\r\n:1\r\n",
             "|1\r\n+meta\r\n+val\r\n",
             ">2\r\n+msg\r\n+data\r\n",


### PR DESCRIPTION
Refs #76
Closes #77

## Why

Every existing fuzz oracle compares the crate against itself:

| Target | Oracle |
| --- | --- |
| `fuzz_*_parse` | did not panic |
| `fuzz_*_roundtrip` | `parse(serialize(f)) == f` |
| `fuzz_*_equivalence` | direct parse agrees with `Parser` |
| `fuzz_*_streaming` | chunked feed agrees with whole-buffer parse |

All closed under a consistent mistake. Measured in #76: seven already-fixed bugs reverted one at a time, roughly 50 million executions against them, zero findings.

## What this adds

**`fuzz_resp2_differential`** compares against `redis-protocol` 6, already a dev-dependency used only by `benches/comparison.rs`. When both accept it asserts framing agreement (consumed length) and value agreement through a normalization layer. The accept/reject directions are constrained by an explicit allowance list.

**`fuzz_unchecked`** compares `parse_frame` against `parse_frame_unchecked` on every input the safe parser accepts. This axis is the only one in the crate empirically proven to find a real bug (#65), and it was unreachable from fuzzing: `fuzz/Cargo.toml` declared `resp-rs` with no `features` key, so `parse_frame_unchecked` was not compiled into any fuzz binary.

## Two live bugs found, both mine

Both are the same shape: a parse-side change not mirrored into the unchecked copy.

**#77**, found by `fuzz_unchecked` in 90 seconds. #56 taught the safe `parse_i64` to accept an explicit `+` but left the unchecked copies stripping only `-`, so the byte stayed in the digit run and `b'+' - b'0'` wrapped:

| Input | `parse_frame` | `parse_frame_unchecked` |
| --- | --- | --- |
| `:+0\r\n` | `Integer(0)` | `Integer(2510)` |
| `:+42\r\n` | `Integer(42)` | `Integer(2552)` |

Silently wrong under the documented contract that validating with `parse_frame` first is sufficient. Shipped in 0.2.0, behind the non-default `unsafe-internals` feature.

**Second, unreported.** The safe parser canonicalizes any non-finite double to a `SpecialFloat`, so `,Inf\r\n` yields `SpecialFloat("inf")`. The unchecked copy only exact-matched lowercase and returned `Double(inf)`.

Both fixed, with cases added to the in-module equivalence tests beside the #65 ones. Reverting only the two parser changes while keeping the tests fails both `unchecked_matches_safe` tests.

## A defect in the reference, not here

The differential target found this on its first run:

```
$1\r\nX!!      ours=InvalidFormat  theirs=BulkString("X")   consumed=7
$3\r\nabcZZ    ours=InvalidFormat  theirs=BulkString("abc") consumed=9
$0\r\nZZ       ours=InvalidFormat  theirs=BulkString("")    consumed=6
```

`redis-protocol` does not verify the CRLF terminating a bulk string body. The grammar is `$<length>\r\n<data>\r\n` with that CRLF required, so this crate is right and the reference is lax. Worth reporting upstream.

Encoded as an allowance, and the cost is stated in the code rather than hidden: in the we-reject-they-accept direction, inputs containing a `$` are not checked. Detecting it exactly needs a reverse mapping whose null handling is ambiguous (`Null` is both `$-1` and `*-1`), and getting that subtly wrong would be worse than the gap. Frames built only from `+` `-` `:` `*` are still checked, which is the direction that would have caught #49.

## Verification

```
fuzz_unchecked             12,278,816 runs clean
fuzz_resp2_differential    10,790,999 runs clean
335 tests pass
```

Both added to the nightly workflow matrix.

## Not done

RESP3 differential. `redis-protocol`'s RESP3 frame attaches attributes to every variant where this crate skips them (#66), and models verbatim strings, doubles, and streaming types differently, so the normalization layer is substantially larger than RESP2's. It wants its own PR and its own review rather than being appended here. #76 stays open for it.